### PR TITLE
Allow using moth/non-moth model as terminal classifier

### DIFF
--- a/trapdata/api/schemas.py
+++ b/trapdata/api/schemas.py
@@ -153,6 +153,7 @@ class AlgorithmCategoryMapResponse(pydantic.BaseModel):
                 {"label": "Not a moth", "index": 1, "gbif_key": 5678},
             ]
         ],
+        repr=False,  # Too long to display in the repr
     )
     labels: list[str] = pydantic.Field(
         default_factory=list,
@@ -161,6 +162,7 @@ class AlgorithmCategoryMapResponse(pydantic.BaseModel):
             "the model."
         ),
         examples=[["Moth", "Not a moth"]],
+        repr=False,  # Too long to display in the repr
     )
     version: str | None = pydantic.Field(
         default=None,

--- a/trapdata/api/schemas.py
+++ b/trapdata/api/schemas.py
@@ -82,6 +82,7 @@ class ClassificationResponse(pydantic.BaseModel):
             "classification in the response. Use the category map from the algorithm "
             "to get the full list of labels and metadata."
         ),
+        repr=False,  # Too long to display in the repr
     )
     scores: list[float] = pydantic.Field(
         default_factory=list,
@@ -89,6 +90,7 @@ class ClassificationResponse(pydantic.BaseModel):
             "The calibrated probabilities for each class label, most commonly "
             "the softmax output."
         ),
+        repr=False,  # Too long to display in the repr
     )
     logits: list[float] = pydantic.Field(
         default_factory=list,
@@ -96,6 +98,7 @@ class ClassificationResponse(pydantic.BaseModel):
             "The raw logits output by the model, before any calibration or "
             "normalization."
         ),
+        repr=False,  # Too long to display in the repr
     )
     inference_time: float | None = None
     algorithm: AlgorithmReference

--- a/trapdata/api/tests/test_api.py
+++ b/trapdata/api/tests/test_api.py
@@ -10,6 +10,8 @@ from trapdata.api.api import (
     PipelineRequest,
     PipelineResponse,
     app,
+    make_algorithm_response,
+    make_pipeline_config_response,
 )
 from trapdata.api.schemas import PipelineConfigRequest, SourceImageRequest
 from trapdata.api.tests.image_server import StaticFileTestServer
@@ -63,11 +65,10 @@ class TestInferenceAPI(TestCase):
             source_images=self.get_test_images(num=2),
         )
         with self.file_server:
-            response = self.client.post(
-                "/pipeline/process", json=pipeline_request.model_dump()
-            )
+            response = self.client.post("/process", json=pipeline_request.model_dump())
             assert response.status_code == 200
-            PipelineResponse(**response.json())
+            results = PipelineResponse(**response.json())
+        return results
 
     def test_config_num_classification_predictions(self):
         """
@@ -124,3 +125,51 @@ class TestInferenceAPI(TestCase):
 
         _send_request(max_predictions_per_classification=1)
         _send_request(max_predictions_per_classification=None)
+
+    def test_pipeline_config_with_binary_classifier(self):
+        BinaryClassifier = CLASSIFIER_CHOICES["moth_binary"]
+        BinaryClassifierResponse = make_algorithm_response(BinaryClassifier)
+
+        SpeciesClassifier = CLASSIFIER_CHOICES["quebec_vermont_moths_2023"]
+        SpeciesClassifierResponse = make_algorithm_response(SpeciesClassifier)
+
+        # Test using a pipeline that finishes with a full species classifier
+        pipeline_config = make_pipeline_config_response(SpeciesClassifier)
+
+        self.assertEqual(len(pipeline_config.algorithms), 3)
+        self.assertEqual(
+            pipeline_config.algorithms[-1].key, SpeciesClassifierResponse.key
+        )
+        self.assertEqual(
+            pipeline_config.algorithms[1].key, BinaryClassifierResponse.key
+        )
+
+        # Test using a pipeline that finishes only with a binary classifier
+        pipeline_config_binary_only = make_pipeline_config_response(BinaryClassifier)
+
+        self.assertEqual(len(pipeline_config_binary_only.algorithms), 2)
+        self.assertEqual(
+            pipeline_config_binary_only.algorithms[-1].key, BinaryClassifierResponse.key
+        )
+        # self.assertTrue(pipeline_config_binary_only.algorithms[-1].terminal)
+
+    def test_processing_with_only_binary_classifier(self):
+        binary_algorithm_key = "moth_binary"
+        binary_algorithm = CLASSIFIER_CHOICES[binary_algorithm_key]
+        pipeline_request = PipelineRequest(
+            pipeline=PipelineChoice[binary_algorithm_key],
+            source_images=self.get_test_images(num=2),
+        )
+        with self.file_server:
+            response = self.client.post("/process", json=pipeline_request.model_dump())
+            assert response.status_code == 200
+            results = PipelineResponse(**response.json())
+
+        for detection in results.detections:
+            for classification in detection.classifications:
+                assert classification.algorithm.key == binary_algorithm_key
+                assert classification.terminal
+                assert classification.labels
+                assert len(classification.labels) == binary_algorithm.num_classes
+                assert classification.scores
+                assert len(classification.scores) == binary_algorithm.num_classes

--- a/trapdata/api/tests/test_api.py
+++ b/trapdata/api/tests/test_api.py
@@ -127,14 +127,19 @@ class TestInferenceAPI(TestCase):
         _send_request(max_predictions_per_classification=None)
 
     def test_pipeline_config_with_binary_classifier(self):
-        BinaryClassifier = CLASSIFIER_CHOICES["moth_binary"]
+        binary_classifier_pipeline_choice = "moth_binary"
+        BinaryClassifier = CLASSIFIER_CHOICES[binary_classifier_pipeline_choice]
         BinaryClassifierResponse = make_algorithm_response(BinaryClassifier)
 
-        SpeciesClassifier = CLASSIFIER_CHOICES["quebec_vermont_moths_2023"]
+        species_classifier_pipeline_choice = "quebec_vermont_moths_2023"
+        SpeciesClassifier = CLASSIFIER_CHOICES[species_classifier_pipeline_choice]
         SpeciesClassifierResponse = make_algorithm_response(SpeciesClassifier)
 
         # Test using a pipeline that finishes with a full species classifier
-        pipeline_config = make_pipeline_config_response(SpeciesClassifier)
+        pipeline_config = make_pipeline_config_response(
+            SpeciesClassifier,
+            slug=species_classifier_pipeline_choice,
+        )
 
         self.assertEqual(len(pipeline_config.algorithms), 3)
         self.assertEqual(
@@ -145,7 +150,9 @@ class TestInferenceAPI(TestCase):
         )
 
         # Test using a pipeline that finishes only with a binary classifier
-        pipeline_config_binary_only = make_pipeline_config_response(BinaryClassifier)
+        pipeline_config_binary_only = make_pipeline_config_response(
+            BinaryClassifier, slug=binary_classifier_pipeline_choice
+        )
 
         self.assertEqual(len(pipeline_config_binary_only.algorithms), 2)
         self.assertEqual(

--- a/trapdata/api/tests/test_models.py
+++ b/trapdata/api/tests/test_models.py
@@ -74,10 +74,16 @@ def make_image():
 
 
 def get_test_images(
-    subdirs: typing.Iterable[str] = ("vermont", "panama"), limit: int = 6
+    subdirs: typing.Iterable[str] = ("vermont", "panama"),
+    limit: int = 6,
+    with_urls: bool = False,
 ) -> list[SourceImage]:
     return [
-        SourceImage(id=str(img["path"].name), filepath=img["path"])
+        SourceImage(
+            id=str(img["path"].name),
+            filepath=img["path"],
+            url=img["url"] if with_urls else None,
+        )
         for subdir in subdirs
         for img in find_images(pathlib.Path(TEST_IMAGES_BASE_PATH) / subdir)
     ][:limit]


### PR DESCRIPTION
- Add Moth / Non-Moth model to allow choices in the API
- Skips running the intermediate / filter model if the binary model is selected as the primary (terminal) classifier
- Add tests that responses return results with correct algorithms based on selection of binary classifier as primary classifier

![image](https://github.com/user-attachments/assets/f5a719df-b9d4-48a8-9378-0cf7a209a28d)

![image](https://github.com/user-attachments/assets/a5bf499e-a4cb-4da3-b104-bbf2e7f82aab)
