### PR TITLE
Add insect order classifier

### DIFF
--- a/trapdata/api/api.py
+++ b/trapdata/api/api.py
@@ -22,6 +22,7 @@ from .models.classification import (
     MothClassifierTuringAnguilla,
     MothClassifierTuringCostaRica,
     MothClassifierUKDenmark,
+    InsectOrderClassifier
 )
 from .models.localization import APIMothDetector
 from .schemas import (
@@ -47,6 +48,7 @@ CLASSIFIER_CHOICES = {
     "anguilla_moths_turing_2024": MothClassifierTuringAnguilla,
     "global_moths_2024": MothClassifierGlobal,
     "moth_binary": MothClassifierBinary,
+    "insect_orders_2025": InsectOrderClassifier
 }
 _classifier_choices = dict(
     zip(CLASSIFIER_CHOICES.keys(), list(CLASSIFIER_CHOICES.keys()))
@@ -57,7 +59,7 @@ PipelineChoice = enum.Enum("PipelineChoice", _classifier_choices)
 
 
 def should_filter_detections(Classifier: type[APIMothClassifier]) -> bool:
-    if Classifier == MothClassifierBinary:
+    if Classifier in [MothClassifierBinary, InsectOrderClassifier]:
         return False
     else:
         return True

--- a/trapdata/api/api.py
+++ b/trapdata/api/api.py
@@ -14,6 +14,7 @@ from ..common.logs import logger  # noqa: F401
 from . import settings
 from .models.classification import (
     APIMothClassifier,
+    InsectOrderClassifier,
     MothClassifierBinary,
     MothClassifierGlobal,
     MothClassifierPanama,
@@ -22,7 +23,6 @@ from .models.classification import (
     MothClassifierTuringAnguilla,
     MothClassifierTuringCostaRica,
     MothClassifierUKDenmark,
-    InsectOrderClassifier
 )
 from .models.localization import APIMothDetector
 from .schemas import (
@@ -48,7 +48,7 @@ CLASSIFIER_CHOICES = {
     "anguilla_moths_turing_2024": MothClassifierTuringAnguilla,
     "global_moths_2024": MothClassifierGlobal,
     "moth_binary": MothClassifierBinary,
-    "insect_orders_2025": InsectOrderClassifier
+    "insect_orders_2025": InsectOrderClassifier,
 }
 _classifier_choices = dict(
     zip(CLASSIFIER_CHOICES.keys(), list(CLASSIFIER_CHOICES.keys()))

--- a/trapdata/api/api.py
+++ b/trapdata/api/api.py
@@ -67,7 +67,6 @@ def should_filter_detections(Classifier: type[APIMothClassifier]) -> bool:
 
 def make_category_map_response(
     model: APIMothDetector | APIMothClassifier,
-    default_taxon_rank: str = "SPECIES",
 ) -> AlgorithmCategoryMapResponse:
     categories_sorted_by_index = sorted(model.category_map.items(), key=lambda x: x[0])
     # as list of dicts:
@@ -75,7 +74,7 @@ def make_category_map_response(
         {
             "index": index,
             "label": label,
-            "taxon_rank": default_taxon_rank,
+            "taxon_rank": model.default_taxon_rank,
         }
         for index, label in categories_sorted_by_index
     ]

--- a/trapdata/api/demo.py
+++ b/trapdata/api/demo.py
@@ -9,6 +9,7 @@ from rich import print
 
 from .models.classification import (
     APIMothClassifier,
+    InsectOrderClassifier,
     MothClassifierBinary,
     MothClassifierGlobal,
     MothClassifierPanama,
@@ -73,6 +74,12 @@ CLASSIFIER_CHOICES = [
         tab_title="Global",
         example_images_dir_names=["vermont", "panama", "denmark"],
         classifier=MothClassifierGlobal,
+    ),
+    ClassifierChoice(
+        key=InsectOrderClassifier.get_key(),
+        tab_title="Insect Orders",
+        example_images_dir_names=["vermont", "panama", "denmark"],
+        classifier=InsectOrderClassifier,
     ),
 ]
 

--- a/trapdata/api/models/classification.py
+++ b/trapdata/api/models/classification.py
@@ -8,6 +8,7 @@ from trapdata.common.logs import logger
 from trapdata.ml.models.classification import (
     GlobalMothSpeciesClassifier,
     InferenceBaseClass,
+    InsectOrderClassifier2025,
     MothNonMothClassifier,
     PanamaMothSpeciesClassifier2024,
     PanamaMothSpeciesClassifierMixedResolution2023,
@@ -187,4 +188,8 @@ class MothClassifierTuringAnguilla(APIMothClassifier, TuringAnguillaSpeciesClass
 
 
 class MothClassifierGlobal(APIMothClassifier, GlobalMothSpeciesClassifier):
+    pass
+
+
+class InsectOrderClassifier(APIMothClassifier, InsectOrderClassifier2025):
     pass

--- a/trapdata/ml/models/base.py
+++ b/trapdata/ml/models/base.py
@@ -76,6 +76,7 @@ class InferenceBaseClass:
     category_map = {}
     num_classes: Union[int, None] = None  # Will use len(category_map) if None
     lookup_gbif_names: bool = False
+    default_taxon_rank: str = "SPECIES"
     model: torch.nn.Module
     normalization = tensorflow_normalization
     transforms: torchvision.transforms.Compose

--- a/trapdata/ml/models/classification.py
+++ b/trapdata/ml/models/classification.py
@@ -107,6 +107,10 @@ class Resnet50(torch.nn.Module):
         return x
 
 
+class ConvNeXtClassifier(InferenceBaseClass):
+    pass
+
+
 class Resnet50Classifier_Turing(InferenceBaseClass):
     # function to run the Turing models
     input_size = 300
@@ -501,3 +505,10 @@ class PanamaMothSpeciesClassifier2024(SpeciesClassifier, Resnet50TimmClassifier)
         "https://object-arbutus.cloud.computecanada.ca/ami-models/moths/classification/"
         "03_ami-gbif_fine-grained_c-america_category_map-with_names.json"
     )
+
+
+class InsectOrderClassifier2025(SpeciesClassifier, ConvNeXtClassifier):
+    name = "Insect Order Classifier"
+    description = "ConvNeXt-T based insect order classifier for 16 classes trained by Mila in January 2025"
+    weights_path = "https://object-arbutus.cloud.computecanada.ca/ami-models/insect_orders/convnext_tiny_in22k_worder0.5_wbinary0.5_run2_checkpoint.pt"
+    labels_path = "https://object-arbutus.cloud.computecanada.ca/ami-models/insect_orders/insect_order_category_map.json"

--- a/trapdata/ml/models/classification.py
+++ b/trapdata/ml/models/classification.py
@@ -108,13 +108,14 @@ class Resnet50(torch.nn.Module):
 
 
 class ConvNeXtOrderClassifier(InferenceBaseClass):
-    """ConvNeXt based insect order classifier"""    
+    """ConvNeXt based insect order classifier"""
+
     input_size = 128
 
     def get_model(self):
         num_classes = len(self.category_map)
         model = timm.create_model(
-            "convnext_tiny.fb_in22k",
+            "convnext_tiny_in22k",
             weights=None,
             num_classes=num_classes,
         )
@@ -127,7 +128,6 @@ class ConvNeXtOrderClassifier(InferenceBaseClass):
         model.eval()
         return model
 
-
     def _pad_to_square(self):
         """Padding transformation to make the image square"""
 
@@ -139,19 +139,17 @@ class ConvNeXtOrderClassifier(InferenceBaseClass):
         else:
             return torchvision.transforms.Pad(padding=[0, 0, 0, 0])
 
-
     def get_transforms(self):
         mean, std = [0.485, 0.456, 0.406], [0.229, 0.224, 0.225]
         return torchvision.transforms.Compose(
-            [   
-                self._pad_to_square(),
+            [
+                # self._pad_to_square(),
                 torchvision.transforms.Resize((self.input_size, self.input_size)),
                 torchvision.transforms.ToTensor(),
                 torchvision.transforms.Normalize(mean, std),
             ]
         )
 
-    
     def post_process_batch(self, output):
         predictions = torch.nn.functional.softmax(output, dim=1)
         predictions = predictions.cpu().numpy()

--- a/trapdata/ml/models/classification.py
+++ b/trapdata/ml/models/classification.py
@@ -293,6 +293,7 @@ class BinaryClassifier(Resnet50ClassifierLowRes):
     type = "binary_classification"
     positive_binary_label: str = constants.POSITIVE_BINARY_LABEL
     negative_binary_label: str = constants.NEGATIVE_BINARY_LABEL
+    default_taxon_rank = "SUPERFAMILY"
 
     def get_queue(self) -> DetectedObjectQueue:
         return DetectedObjectQueue(self.db_path, self.image_base_path)
@@ -564,3 +565,4 @@ class InsectOrderClassifier2025(SpeciesClassifier, ConvNeXtOrderClassifier):
     description = "ConvNeXt-T based insect order classifier for 16 classes trained by Mila in January 2025"
     weights_path = "https://object-arbutus.cloud.computecanada.ca/ami-models/insect_orders/convnext_tiny_in22k_worder0.5_wbinary0.5_run2_checkpoint.pt"
     labels_path = "https://object-arbutus.cloud.computecanada.ca/ami-models/insect_orders/insect_order_category_map.json"
+    default_taxon_rank = "ORDER"


### PR DESCRIPTION
This PR integrates the insect order classifier trained by Mila into the ADC / Antenna platform. The model is trained with a custom loss function which penalizes simultaneously on binary- and order-level classification.