### PR TITLE
Add model for Kenya & Uganda moths from UKCEH / Turing

### DIFF
--- a/trapdata/api/api.py
+++ b/trapdata/api/api.py
@@ -22,11 +22,7 @@ from .models.classification import (
     MothClassifierQuebecVermont,
     MothClassifierTuringAnguilla,
     MothClassifierTuringCostaRica,
-    MothClassifierTuringJapan,
     MothClassifierTuringKenyaUganda,
-    MothClassifierTuringMadagascar,
-    MothClassifierTuringSingapore,
-    MothClassifierTuringThailand,
     MothClassifierUKDenmark,
 )
 from .models.localization import APIMothDetector
@@ -51,11 +47,7 @@ CLASSIFIER_CHOICES = {
     "uk_denmark_moths_2023": MothClassifierUKDenmark,
     "costa_rica_moths_turing_2024": MothClassifierTuringCostaRica,
     "anguilla_moths_turing_2024": MothClassifierTuringAnguilla,
-    "singapore_moths_turing_2024": MothClassifierTuringSingapore,
-    "thailand_moths_turing_2024": MothClassifierTuringThailand,
-    "madagascar_moths_turing_2024": MothClassifierTuringMadagascar,
     "kenya-uganda_moths_turing_2024": MothClassifierTuringKenyaUganda,
-    "japan_moths_turing_2024": MothClassifierTuringJapan,
     "global_moths_2024": MothClassifierGlobal,
     "moth_binary": MothClassifierBinary,
     "insect_orders_2025": InsectOrderClassifier,

--- a/trapdata/api/models/classification.py
+++ b/trapdata/api/models/classification.py
@@ -15,11 +15,7 @@ from trapdata.ml.models.classification import (
     QuebecVermontMothSpeciesClassifier2024,
     TuringAnguillaSpeciesClassifier,
     TuringCostaRicaSpeciesClassifier,
-    TuringJapanSpeciesClassifier,
     TuringKenyaUgandaSpeciesClassifier,
-    TuringMadagascarSpeciesClassifier,
-    TuringSingaporeSpeciesClassifier,
-    TuringThailandSpeciesClassifier,
     UKDenmarkMothSpeciesClassifier2024,
 )
 
@@ -192,28 +188,8 @@ class MothClassifierTuringAnguilla(APIMothClassifier, TuringAnguillaSpeciesClass
     pass
 
 
-class MothClassifierTuringJapan(APIMothClassifier, TuringJapanSpeciesClassifier):
-    pass
-
-
 class MothClassifierTuringKenyaUganda(
     APIMothClassifier, TuringKenyaUgandaSpeciesClassifier
-):
-    pass
-
-
-class MothClassifierTuringMadagascar(
-    APIMothClassifier, TuringMadagascarSpeciesClassifier
-):
-    pass
-
-
-class MothClassifierTuringThailand(APIMothClassifier, TuringThailandSpeciesClassifier):
-    pass
-
-
-class MothClassifierTuringSingapore(
-    APIMothClassifier, TuringSingaporeSpeciesClassifier
 ):
     pass
 

--- a/trapdata/ml/models/classification.py
+++ b/trapdata/ml/models/classification.py
@@ -406,43 +406,27 @@ class TuringCostaRicaSpeciesClassifier(SpeciesClassifier, Resnet50Classifier_Tur
 class TuringAnguillaSpeciesClassifier(SpeciesClassifier, Resnet50Classifier_Turing):
     name = "Turing Anguilla Species Classifier"
     description = "Trained on 28th June 2024 by Turing team using Resnet50 model."
-    weights_path = "https://object-arbutus.cloud.computecanada.ca/ami-models/moths/classification/turing-anguilla_v01_resnet50_2024-06-28-17-01_state.pt"
-    labels_path = "https://object-arbutus.cloud.computecanada.ca/ami-models/moths/classification/01_anguilla_data_category_map.json"
-
-
-class TuringThailandSpeciesClassifier(SpeciesClassifier, Resnet50Classifier_Turing):
-    name = "Turing Thailand Species Classifier"
-    description = "Trained on 11th November 2024 by Turing team using Resnet50 model."
-    weights_path = "https://object-arbutus.cloud.computecanada.ca/ami-models/moths/classification//turing-thailand_v01_resnet50_2024-11-21-16-28_state.pt"
-    labels_path = "https://object-arbutus.cloud.computecanada.ca/ami-models/moths/classification//01_thailand_data_category_map.json"
-
-
-class TuringMadagascarSpeciesClassifier(SpeciesClassifier, Resnet50Classifier_Turing):
-    name = "Turing Madagascar Species Classifier"
-    description = "Trained on 11th November 2024 by Turing team using Resnet50 model."
-    weights_path = "https://object-arbutus.cloud.computecanada.ca/ami-models/moths/classification//turing-madagascar_v01_resnet50_2024-07-01-13-01_state.pt"
-    labels_path = "https://object-arbutus.cloud.computecanada.ca/ami-models/moths/classification//01_madagascar_data_category_map.json"
+    weights_path = (
+        "https://object-arbutus.cloud.computecanada.ca/ami-models/moths/classification/"
+        "turing-anguilla_v01_resnet50_2024-06-28-17-01_state.pt"
+    )
+    labels_path = (
+        "https://object-arbutus.cloud.computecanada.ca/ami-models/moths/classification/"
+        "01_anguilla_data_category_map.json"
+    )
 
 
 class TuringKenyaUgandaSpeciesClassifier(SpeciesClassifier, Resnet50Classifier_Turing):
     name = "Turing Kenya and Uganda Species Classifier"
     description = "Trained on 19th November 2024 by Turing team using Resnet50 model."
-    weights_path = "https://object-arbutus.cloud.computecanada.ca/ami-models/moths/classification//turing-kenya-uganda_v01_resnet50_2024-11-19-18-44_state.pt"
-    labels_path = "https://object-arbutus.cloud.computecanada.ca/ami-models/moths/classification//01_kenya-uganda_data_category_map.json"
-
-
-class TuringJapanSpeciesClassifier(SpeciesClassifier, Resnet50Classifier_Turing):
-    name = "Turing Japan Species Classifier"
-    description = "Trained on 19th November 2024 by Turing team using Resnet50 model."
-    weights_path = "https://object-arbutus.cloud.computecanada.ca/ami-models/moths/classification//turing-japan_v01_resnet50_2024-11-22-17-22_state.pt"
-    labels_path = "https://object-arbutus.cloud.computecanada.ca/ami-models/moths/classification//01_japan_data_category_map.json"
-
-
-class TuringSingaporeSpeciesClassifier(SpeciesClassifier, Resnet50Classifier_Turing):
-    name = "Turing Singapore Species Classifier"
-    description = "Trained on 21st November 2024 by Turing team using Resnet50 model."
-    weights_path = "https://object-arbutus.cloud.computecanada.ca/ami-models/moths/classification//turing-singapore_v02_resnet50_2024-11-21-19-58_state.pt"
-    labels_path = "https://object-arbutus.cloud.computecanada.ca/ami-models/moths/classification//02_singapore_data_category_map.json"
+    weights_path = (
+        "https://object-arbutus.cloud.computecanada.ca/ami-models/moths/classification/"
+        "turing-kenya-uganda_v01_resnet50_2024-11-19-18-44_state.pt"
+    )
+    labels_path = (
+        "https://object-arbutus.cloud.computecanada.ca/ami-models/moths/classification/"
+        "01_kenya-uganda_data_category_map.json"
+    )
 
 
 class TuringUKSpeciesClassifier(SpeciesClassifier, Resnet50Classifier_Turing):


### PR DESCRIPTION
Adds the following model to the API and core classifiers:
- kenya-uganda (v01)

Other models in https://github.com/RolnickLab/ami-data-companion/pull/72 were excluded because the weights are not yet available.