### PR TITLE
Update exporter for importing data into to Antenna 

### DIFF
--- a/trapdata/api/export_utils.py
+++ b/trapdata/api/export_utils.py
@@ -303,9 +303,20 @@ def get_source_images_from_occurrences(occurrences: list) -> list[SourceImageRes
     Returns:
         List of SourceImageResponse objects
     """
+    from trapdata.api.schemas import DeploymentReference
+
     source_images = {}
 
     for occurrence in occurrences:
+        # Get deployment information from the occurrence
+        deployment_name = occurrence.get("deployment")
+        deployment = None
+        if deployment_name:
+            deployment = DeploymentReference(
+                name=deployment_name,
+                key=deployment_name,  # Use same value for key as name
+            )
+
         examples = occurrence.get("examples", [])
         for example in examples:
             source_image_id = str(example.get("source_image_id", "unknown"))
@@ -315,6 +326,7 @@ def get_source_images_from_occurrences(occurrences: list) -> list[SourceImageRes
                 source_images[source_image_id] = SourceImageResponse(
                     id=source_image_id,
                     url=source_image_path,
+                    deployment=deployment,
                 )
 
     return list(source_images.values())
@@ -341,7 +353,7 @@ def create_pipeline_results_response(
     # Get current algorithms
     algorithms = get_current_algorithms()
 
-    # Get source images
+    # Get source images with deployment information
     source_images = get_source_images_from_occurrences(occurrences)
 
     return PipelineResultsResponse(

--- a/trapdata/api/export_utils.py
+++ b/trapdata/api/export_utils.py
@@ -1,0 +1,353 @@
+"""
+Utilities for converting database models to API schemas for export functionality.
+"""
+
+import datetime
+from typing import Optional, Protocol
+
+from trapdata import ml
+from trapdata.api.schemas import (
+    AlgorithmConfigResponse,
+    AlgorithmReference,
+    BoundingBox,
+    ClassificationResponse,
+    DetectionResponse,
+    PipelineResultsResponse,
+    SourceImageResponse,
+)
+from trapdata.settings import read_settings
+
+
+class DetectedObjectLike(Protocol):
+    """Protocol for objects that behave like DetectedObject for conversion."""
+
+    id: Optional[int]
+    specific_label: Optional[str]
+    specific_label_score: Optional[float]
+    bbox: Optional[list[int]]
+    path: Optional[str]
+    timestamp: Optional[datetime.datetime]
+    detection_algorithm: Optional[str]
+    classification_algorithm: Optional[str]
+
+
+def create_algorithm_reference(
+    algorithm_name: Optional[str], task_type: str = "detection"
+) -> AlgorithmReference:
+    """
+    Create an AlgorithmReference from an algorithm name.
+
+    Args:
+        algorithm_name: Name of the algorithm, may be None for legacy data
+        task_type: Type of task (detection, classification)
+
+    Returns:
+        AlgorithmReference object
+    """
+    if not algorithm_name:
+        if task_type == "detection":
+            algorithm_name = "unknown_detector"
+            key = "unknown_detector"
+        else:
+            algorithm_name = "unknown_classifier"
+            key = "unknown_classifier"
+        return AlgorithmReference(name=algorithm_name, key=key)
+
+    # Try to find the actual algorithm key from the model classes
+    current_settings = read_settings()
+
+    if task_type == "detection":
+        detector_choice = current_settings.localization_model
+        detector_class = ml.models.object_detectors.get(detector_choice.value)
+        if detector_class and detector_class.name == algorithm_name:
+            key = detector_class.get_key()
+        else:
+            # Fallback to generated key
+            key = algorithm_name.lower().replace(" ", "_").replace("-", "_")
+    else:
+        # Check species classifier first
+        species_choice = current_settings.species_classification_model
+        species_class = ml.models.species_classifiers.get(species_choice.value)
+        if species_class and species_class.name == algorithm_name:
+            key = species_class.get_key()
+        else:
+            # Check binary classifier
+            binary_choice = current_settings.binary_classification_model
+            binary_class = ml.models.binary_classifiers.get(binary_choice.value)
+            if binary_class and binary_class.name == algorithm_name:
+                key = binary_class.get_key()
+            else:
+                # Fallback to generated key
+                key = algorithm_name.lower().replace(" ", "_").replace("-", "_")
+
+    return AlgorithmReference(name=algorithm_name, key=key)
+
+
+def convert_classification_to_classification_response(
+    detected_obj: DetectedObjectLike,
+    algorithm_name: Optional[str] = None,
+    timestamp: Optional[datetime.datetime] = None,
+) -> ClassificationResponse:
+    """
+    Convert classification data from a DetectedObject to ClassificationResponse.
+
+    Args:
+        detected_obj: Database DetectedObject with classification data
+        algorithm_name: Name of classification algorithm used
+        timestamp: Timestamp for the classification
+
+    Returns:
+        ClassificationResponse object
+    """
+    if timestamp is None:
+        timestamp = detected_obj.timestamp or datetime.datetime.now()
+
+    # Use the specific label and score from the detected object
+    classification = detected_obj.specific_label or "unknown"
+    score = detected_obj.specific_label_score or 0.0
+
+    # Create algorithm reference
+    algorithm = create_algorithm_reference(
+        algorithm_name or detected_obj.classification_algorithm,
+        task_type="classification",
+    )
+
+    return ClassificationResponse(
+        classification=classification,
+        labels=None,  # Not available in database model
+        scores=[score],  # Single score for the predicted class
+        logits=[],  # Not stored in database
+        inference_time=None,  # Not stored in database
+        algorithm=algorithm,
+        terminal=True,
+        timestamp=timestamp,
+    )
+
+
+def convert_detected_object_to_detection_response(
+    detected_obj: DetectedObjectLike,
+    source_image_id: str,
+    crop_image_url: Optional[str] = None,
+    detection_algorithm_name: Optional[str] = None,
+    classification_algorithm_name: Optional[str] = None,
+) -> DetectionResponse:
+    """
+    Convert a DetectedObject from database to DetectionResponse API schema.
+
+    Args:
+        detected_obj: Database DetectedObject
+        source_image_id: ID of the source image
+        crop_image_url: URL to the cropped image (optional)
+        detection_algorithm_name: Name of detection algorithm used
+        classification_algorithm_name: Name of classification algorithm used
+
+    Returns:
+        DetectionResponse object with embedded ClassificationResponse
+    """
+    # Convert bounding box from list to BoundingBox object
+    bbox_coords = detected_obj.bbox or [0, 0, 0, 0]
+    # Convert int coordinates to float for BoundingBox
+    bbox_coords_float = [float(coord) for coord in bbox_coords]
+    bbox = BoundingBox.from_coords(bbox_coords_float)
+
+    # Create detection algorithm reference
+    detection_algorithm = create_algorithm_reference(
+        detection_algorithm_name or detected_obj.detection_algorithm,
+        task_type="detection",
+    )
+
+    # Create classification response if classification data exists
+    classifications = []
+    if detected_obj.specific_label:
+        classification_response = convert_classification_to_classification_response(
+            detected_obj,
+            algorithm_name=classification_algorithm_name,
+            timestamp=detected_obj.timestamp,
+        )
+        classifications.append(classification_response)
+
+    # Use crop image path as URL if available
+    if not crop_image_url and detected_obj.path:
+        crop_image_url = str(detected_obj.path)
+
+    return DetectionResponse(
+        source_image_id=source_image_id,
+        bbox=bbox,
+        inference_time=None,  # Not stored in database
+        algorithm=detection_algorithm,
+        timestamp=detected_obj.timestamp or datetime.datetime.now(),
+        crop_image_url=crop_image_url,
+        classifications=classifications,
+    )
+
+
+def convert_occurrence_to_detection_responses(
+    occurrence_data: dict,
+    detection_algorithm_name: Optional[str] = None,
+    classification_algorithm_name: Optional[str] = None,
+) -> list[DetectionResponse]:
+    """
+    Convert occurrence data (with examples) to a list of DetectionResponse objects.
+
+    Args:
+        occurrence_data: Dictionary containing occurrence data with examples
+        detection_algorithm_name: Name of detection algorithm used
+        classification_algorithm_name: Name of classification algorithm used
+
+    Returns:
+        List of DetectionResponse objects
+    """
+    detection_responses = []
+
+    # Get current algorithm names from settings if not provided
+    if not detection_algorithm_name or not classification_algorithm_name:
+        current_settings = read_settings()
+
+        if not detection_algorithm_name:
+            detector_choice = current_settings.localization_model
+            detector_class = ml.models.object_detectors.get(detector_choice.value)
+            if detector_class:
+                detection_algorithm_name = detector_class.name
+
+        if not classification_algorithm_name:
+            species_choice = current_settings.species_classification_model
+            species_class = ml.models.species_classifiers.get(species_choice.value)
+            if species_class:
+                classification_algorithm_name = species_class.name
+
+    examples = occurrence_data.get("examples", [])
+    for example in examples:
+        # Create a mock DetectedObject from the example data
+        class MockDetectedObject:
+            def __init__(self, example_data):
+                self.id = example_data.get("id")
+                self.specific_label = example_data.get("label")
+                self.specific_label_score = example_data.get("score")
+                self.bbox = example_data.get("bbox", [0, 0, 0, 0])
+                self.path = example_data.get("cropped_image_path")
+                self.timestamp = example_data.get("timestamp")
+                self.detection_algorithm = detection_algorithm_name
+                self.classification_algorithm = classification_algorithm_name
+
+        mock_obj = MockDetectedObject(example)
+        source_image_id = str(example.get("source_image_id", "unknown"))
+
+        detection_response = convert_detected_object_to_detection_response(
+            mock_obj,
+            source_image_id=source_image_id,
+            detection_algorithm_name=detection_algorithm_name,
+            classification_algorithm_name=classification_algorithm_name,
+        )
+
+        detection_responses.append(detection_response)
+
+    return detection_responses
+
+
+def get_current_algorithms() -> dict[str, AlgorithmConfigResponse]:
+    """
+    Get the currently configured algorithms from settings.
+
+    Returns:
+        Dictionary of algorithm configurations keyed by algorithm key
+    """
+    current_settings = read_settings()
+    algorithms = {}
+
+    # Get object detector
+    detector_choice = current_settings.localization_model
+    detector_class = ml.models.object_detectors.get(detector_choice.value)
+    if detector_class:
+        algorithms[detector_class.get_key()] = AlgorithmConfigResponse(
+            name=detector_class.name,
+            key=detector_class.get_key(),
+            task_type="detection",
+            description=getattr(detector_class, "description", None),
+            version=1,
+        )
+
+    # Get binary classifier
+    binary_choice = current_settings.binary_classification_model
+    binary_class = ml.models.binary_classifiers.get(binary_choice.value)
+    if binary_class:
+        algorithms[binary_class.get_key()] = AlgorithmConfigResponse(
+            name=binary_class.name,
+            key=binary_class.get_key(),
+            task_type="classification",
+            description=getattr(binary_class, "description", None),
+            version=1,
+        )
+
+    # Get species classifier
+    species_choice = current_settings.species_classification_model
+    species_class = ml.models.species_classifiers.get(species_choice.value)
+    if species_class:
+        algorithms[species_class.get_key()] = AlgorithmConfigResponse(
+            name=species_class.name,
+            key=species_class.get_key(),
+            task_type="classification",
+            description=getattr(species_class, "description", None),
+            version=1,
+        )
+
+    return algorithms
+
+
+def get_source_images_from_occurrences(occurrences: list) -> list[SourceImageResponse]:
+    """
+    Extract unique source images from occurrence data.
+
+    Args:
+        occurrences: List of occurrence dictionaries with examples
+
+    Returns:
+        List of SourceImageResponse objects
+    """
+    source_images = {}
+
+    for occurrence in occurrences:
+        examples = occurrence.get("examples", [])
+        for example in examples:
+            source_image_id = str(example.get("source_image_id", "unknown"))
+            source_image_path = example.get("source_image_path", "")
+
+            if source_image_id not in source_images:
+                source_images[source_image_id] = SourceImageResponse(
+                    id=source_image_id,
+                    url=source_image_path,
+                )
+
+    return list(source_images.values())
+
+
+def create_pipeline_results_response(
+    occurrences: list,
+    detection_responses: list[DetectionResponse],
+    pipeline_name: str = "local_batch_processor",
+    total_time: float = 0.0,
+) -> PipelineResultsResponse:
+    """
+    Create a complete PipelineResultsResponse from occurrence data and responses.
+
+    Args:
+        occurrences: List of occurrence dictionaries
+        detection_responses: List of DetectionResponse objects
+        pipeline_name: Name of the pipeline used
+        total_time: Total processing time
+
+    Returns:
+        Complete PipelineResultsResponse object
+    """
+    # Get current algorithms
+    algorithms = get_current_algorithms()
+
+    # Get source images
+    source_images = get_source_images_from_occurrences(occurrences)
+
+    return PipelineResultsResponse(
+        pipeline=pipeline_name,
+        algorithms=algorithms,
+        total_time=total_time,
+        source_images=source_images,
+        detections=detection_responses,
+    )

--- a/trapdata/api/export_utils.py
+++ b/trapdata/api/export_utils.py
@@ -18,7 +18,7 @@ from trapdata.api.schemas import (
 from trapdata.settings import read_settings
 
 
-class DetectedObjectLike(Protocol):
+class DetectedObjectProtocol(Protocol):
     """Protocol for objects that behave like DetectedObject for conversion."""
 
     id: Optional[int]
@@ -84,7 +84,7 @@ def create_algorithm_reference(
 
 
 def convert_classification_to_classification_response(
-    detected_obj: DetectedObjectLike,
+    detected_obj: DetectedObjectProtocol,
     algorithm_name: Optional[str] = None,
     timestamp: Optional[datetime.datetime] = None,
 ) -> ClassificationResponse:
@@ -125,7 +125,7 @@ def convert_classification_to_classification_response(
 
 
 def convert_detected_object_to_detection_response(
-    detected_obj: DetectedObjectLike,
+    detected_obj: DetectedObjectProtocol,
     source_image_id: str,
     crop_image_url: Optional[str] = None,
     detection_algorithm_name: Optional[str] = None,

--- a/trapdata/api/schemas.py
+++ b/trapdata/api/schemas.py
@@ -40,6 +40,7 @@ class SourceImage(pydantic.BaseModel):
     width: int | None = None
     height: int | None = None
     timestamp: datetime.datetime | None = None
+    deployment: "DeploymentReference | None" = None
 
     # Validate that there is at least one of the following fields
     @pydantic.model_validator(mode="after")
@@ -65,6 +66,23 @@ class SourceImage(pydantic.BaseModel):
         if self._pil:
             self.width, self.height = self._pil.size
         return self._pil
+
+
+class DeploymentReference(pydantic.BaseModel):
+    """Reference to a deployment."""
+
+    name: str = pydantic.Field(
+        description="Name of the deployment, e.g. 'Vermont Moth Camera Station 1'.",
+        examples=["vermont-moth-camera-station-1"],
+    )
+    key: str = pydantic.Field(
+        description=(
+            "A unique key for the deployment, used to reference it in the API. "
+            "In practive the ADC's deployment key and name are the same and are "
+            "derived from the root folder name of the source image."
+        ),
+        examples=["vermont-moth-camera-station-1"],
+    )
 
 
 class AlgorithmReference(pydantic.BaseModel):
@@ -277,6 +295,7 @@ class PipelineResultsResponse(pydantic.BaseModel):
     total_time: float
     source_images: list[SourceImageResponse]
     detections: list[DetectionResponse]
+    deployments: list[DeploymentReference] | None = None
     config: PipelineConfigRequest = PipelineConfigRequest()
 
 

--- a/trapdata/api/schemas.py
+++ b/trapdata/api/schemas.py
@@ -159,6 +159,7 @@ class SourceImageResponse(pydantic.BaseModel):
 
     id: str
     url: str
+    deployment: "DeploymentReference | None" = None
 
 
 class AlgorithmCategoryMapResponse(pydantic.BaseModel):

--- a/trapdata/cli/export.py
+++ b/trapdata/cli/export.py
@@ -275,7 +275,7 @@ def deployments(
 @cli.command(name="api-occurrences")
 def api_occurrences(
     format: ExportFormat = ExportFormat.json,
-    num_examples: int = 3,
+    num_examples: int = 9999,
     limit: Optional[int] = None,
     offset: int = 0,
     outfile: Optional[pathlib.Path] = None,

--- a/trapdata/cli/export.py
+++ b/trapdata/cli/export.py
@@ -431,9 +431,19 @@ def api_occurrences(
             flattened_dicts.append(flat_dict)
 
         df = pd.DataFrame(flattened_dicts)
+        return export(df=df, format=format, outfile=outfile)
     else:
-        # For JSON/HTML, export the full pipeline response
-        pipeline_dict = pipeline_response.model_dump()
-        df = pd.DataFrame([pipeline_dict])
+        # For JSON/HTML, export the full pipeline response directly
+        import json
 
-    return export(df=df, format=format, outfile=outfile)
+        pipeline_dict = pipeline_response.model_dump()
+
+        if outfile:
+            with open(outfile, "w") as f:
+                json.dump(pipeline_dict, f, indent=2, default=str)
+            logger.info(f'Exported pipeline response to "{outfile}"')
+            return str(outfile.absolute())
+        else:
+            output = json.dumps(pipeline_dict, indent=2, default=str)
+            print(output)
+            return output

--- a/trapdata/cli/export.py
+++ b/trapdata/cli/export.py
@@ -274,8 +274,9 @@ def deployments(
 
 @cli.command(name="api-occurrences")
 def api_occurrences(
+    pipeline_slug: str,
     format: ExportFormat = ExportFormat.json,
-    num_examples: int = 9999,
+    num_examples: int = 3,
     limit: Optional[int] = None,
     offset: int = 0,
     outfile: Optional[pathlib.Path] = None,
@@ -291,7 +292,10 @@ def api_occurrences(
     This exports the same occurrence data as the 'occurrences' command but uses
     the new API schema format with DetectionResponse and ClassificationResponse
     objects instead of the legacy Occurrence and ExportedDetection formats.
+
+    Pipeline must be one of the valid choices from CLASSIFIER_CHOICES
     """
+    # Validate pipeline choice
     events = get_monitoring_sessions_from_db(
         db_path=settings.database_url, base_directory=settings.image_base_path
     )
@@ -330,7 +334,7 @@ def api_occurrences(
     pipeline_response = create_pipeline_results_response(
         occurrences=occurrence_dicts,
         detection_responses=all_detection_responses,
-        pipeline_name="local_batch_processor",
+        pipeline_name=pipeline_slug,
         total_time=0.0,
         include_category_maps=include_category_maps,
     )

--- a/trapdata/cli/export.py
+++ b/trapdata/cli/export.py
@@ -283,6 +283,7 @@ def api_occurrences(
     absolute_paths: bool = False,
     detection_algorithm: Optional[str] = None,
     classification_algorithm: Optional[str] = None,
+    include_category_maps: bool = False,
 ) -> Optional[str]:
     """
     Export occurrences using API schemas (DetectionResponse/ClassificationResponse).
@@ -331,6 +332,7 @@ def api_occurrences(
         detection_responses=all_detection_responses,
         pipeline_name="local_batch_processor",
         total_time=0.0,
+        include_category_maps=include_category_maps,
     )
 
     logger.info(
@@ -377,7 +379,7 @@ def api_occurrences(
                             destination.relative_to(destination_dir)
                         )
 
-    # Convert to DataFrame for export based on format
+    # Handle export based on format
     if format in tabular_formats:
         # For CSV, flatten the detection responses structure
         detection_dicts = [

--- a/trapdata/cli/export.py
+++ b/trapdata/cli/export.py
@@ -213,7 +213,7 @@ def sessions(
 
 @cli.command()
 def captures(
-    date: datetime.datetime,
+    date: Optional[datetime.datetime] = None,
     format: ExportFormat = ExportFormat.json,
     outfile: Optional[pathlib.Path] = None,
 ) -> Optional[str]:
@@ -224,16 +224,28 @@ def captures(
     """
     Session = get_session_class(settings.database_url)
     session = Session()
+    if date is not None:
+        event_dates = [date.date()]
+    else:
+        event_dates = [
+            event.day
+            for event in get_monitoring_sessions_from_db(
+                db_path=settings.database_url, base_directory=settings.image_base_path
+            )
+        ]
     events = get_monitoring_session_by_date(
         db_path=settings.database_url,
         base_directory=settings.image_base_path,
-        event_dates=[str(date.date())],
+        event_dates=event_dates,
     )
-    if not len(events):
+    if date and not len(events):
         raise Exception(f"No Monitoring Event with date: {date.date()}")
 
-    event = events[0]
-    captures = get_monitoring_session_images(settings.database_url, event, limit=100)
+    captures = []
+    for event in events:
+        captures += get_monitoring_session_images(
+            settings.database_url, event, limit=100
+        )
     [session.add(img) for img in captures]
 
     df = pd.DataFrame([img.report_detail().model_dump() for img in captures])

--- a/trapdata/common/logs.py
+++ b/trapdata/common/logs.py
@@ -3,7 +3,7 @@ import logging
 import structlog
 
 structlog.configure(
-    wrapper_class=structlog.make_filtering_bound_logger(logging.INFO),
+    wrapper_class=structlog.make_filtering_bound_logger(logging.DEBUG),
 )
 
 

--- a/trapdata/db/models/images.py
+++ b/trapdata/db/models/images.py
@@ -29,6 +29,9 @@ class CaptureListItem(BaseModel):
 class CaptureDetail(CaptureListItem):
     id: int
     event: object
+    url: Optional[str] = None
+    event: object
+    deployment: str
     notes: Optional[str]
     detections: list
     filesize: int
@@ -121,11 +124,14 @@ class TrapImage(Base):
         return CaptureListItem(
             id=self.id,
             source_image=f"{constants.IMAGE_BASE_URL}vermont/snapshots/{self.path}",
+            path=self.path,
             timestamp=self.timestamp,
             last_read=self.last_read,
             last_processed=self.last_processed,
             in_queue=self.in_queue,
             num_detections=self.num_detected_objects,
+            event=self.monitoring_session.day,
+            deployment=self.monitoring_session.deployment,
         )
 
     def report_detail(self) -> CaptureDetail:

--- a/trapdata/db/models/occurrences.py
+++ b/trapdata/db/models/occurrences.py
@@ -159,11 +159,15 @@ def get_unique_species_by_track(
                 models.DetectedObject.id,
                 models.DetectedObject.image_id.label("source_image_id"),
                 models.TrapImage.path.label("source_image_path"),
+                models.TrapImage.width.label("source_image_width"),
+                models.TrapImage.height.label("source_image_height"),
+                models.TrapImage.filesize.label("source_image_filesize"),
                 models.DetectedObject.specific_label.label("label"),
                 models.DetectedObject.specific_label_score.label("score"),
                 models.DetectedObject.path.label("cropped_image_path"),
                 models.DetectedObject.sequence_id,
                 models.DetectedObject.timestamp,
+                models.DetectedObject.bbox,
             )
             .where(
                 (models.DetectedObject.monitoring_session_id == monitoring_session.id)

--- a/trapdata/db/models/occurrences.py
+++ b/trapdata/db/models/occurrences.py
@@ -18,6 +18,29 @@ from trapdata import db
 from trapdata.db import models
 
 
+class ExportedDetection(pydantic.BaseModel):
+    id: int
+    source_image_id: int
+    source_image_path: str
+    source_image_width: int
+    source_image_height: int
+    source_image_filesize: int
+    label: str
+    score: float
+    cropped_image_path: str | None = None
+    sequence_id: str | None = (
+        None  # This is the Occurrence ID on the ADC side (= detections in a sequence)
+    )
+    timestamp: datetime.datetime
+    detection_algorithm: str | None = (
+        None  # Name of the object detection algorithm used
+    )
+    classification_algorithm: str | None = (
+        None  # Classification algorithm used to generate the label & score
+    )
+    bbox: list[int]  # Bounding box in the format [x_min, y_min, x_max, y_max]
+
+
 class Occurrence(pydantic.BaseModel):
     id: str
     label: str
@@ -30,7 +53,7 @@ class Occurrence(pydantic.BaseModel):
     num_frames: int
     # cropped_image_path: pathlib.Path
     # source_image_id: int
-    examples: list[dict]
+    examples: list[ExportedDetection] = []
     example_crop: Optional[pathlib.Path] = None
     # detections: list[object]
     # deployment: object


### PR DESCRIPTION
## Summary

This PR teaches the AMI Data Companion to export its locally-processed results in the format Antenna ingests, so a project that was processed offline can be loaded into the web platform. ADC can process local images much faster than triggering processing from Antenna, and this is the bridge that gets that work back online. The matching import side is [RolnickLab/antenna#916](https://github.com/RolnickLab/antenna/pull/916), which feeds the exported file through the same `save_results` path Antenna uses for live processing.

The export produces one or more `PipelineResultsResponse` JSON files — the same schema Antenna's processing services return — built from the occurrences already stored in the local ADC database. Large runs are split into batches so each file stays a manageable size, and crop images can optionally be collected alongside the JSON.

## How to use

```bash
ami export api-occurrences <PIPELINE_SLUG> \
    [--images-per-batch 100]     # source images per output file (default 100)
    [--collect-images]           # copy crop images into a <name>_images/ folder
    [--absolute-paths]           # write absolute crop paths instead of relative
    [--limit N] [--offset N]     # subset of occurrences
    [--outfile path.json]        # naming/location of output (batches get _batch_NNN suffix)
    [--format json|csv]
```

- `PIPELINE_SLUG` is the pipeline reference as registered in Antenna.
- Output is written to the export directory as `*_batch_001.json`, `*_batch_002.json`, … each a complete `PipelineResultsResponse`.
- Import each file into Antenna with `python manage.py import_pipeline_results <file> --project <id> --create-new-algorithms` (see the paired PR).

## List of Changes

| # | Change (what it does) | How (implementation) |
|---|------------------------|----------------------|
| 1 | New `export api-occurrences` command produces Antenna-importable results. | `trapdata/cli/export.py`: new `api_occurrences` command; converts stored occurrences to `PipelineResultsResponse` and writes batched JSON. |
| 2 | Exports carry which deployment each capture belongs to. | New `DeploymentReference` schema; `deployment` added to `SourceImage` and `SourceImageResponse`; `deployments` added to `PipelineResultsResponse`. |
| 3 | Database records are converted to the API schema in one place. | New `trapdata/api/export_utils.py` with converters from `DetectedObject` / occurrence dicts to `DetectionResponse` / `ClassificationResponse` / `PipelineResultsResponse`. |
| 4 | Large exports are split into multiple files. | `_export_batched_pipeline_responses` batches by source-image count (`--images-per-batch`) or detection count, naming files `*_batch_NNN.json`. |
| 5 | Crops can be exported next to the JSON. | `--collect-images` copies crop images into a `<name>_images/` folder and rewrites `crop_image_url` to point at them. |
| 6 | `captures` export can run across all sessions, not just one date. | `captures` command's `date` argument is now optional; without it, all monitoring sessions are exported. |

## Status / TODO

This is a work in progress. Before merge:

- [ ] Test end to end against a live Antenna instance (import a real export through antenna#916).
- [ ] Export classification features / logits (currently `logits=[]` and features are not exported).
- [ ] Category maps (`--include-category-maps` currently raises `NotImplementedError`).

## Follow-ups and Discussion

These come out of reviewing the export against what the Antenna importer needs.

1. **Occurrence/track associations are flattened away.** `convert_occurrence_to_detection_responses` walks each occurrence's `examples` and emits independent `DetectionResponse`s with no occurrence/track id. Antenna's model supports multi-detection occurrences (tracks) via `Detection.occurrence`, and the goal is to import them — but that needs the export to keep the occurrence id on each detection. Proposed: add an optional `sequence_id` / `track_id` to `DetectionResponse` (a pure grouping key) set from the ADC occurrence id, and have Antenna group by it on import. Without this, every imported detection becomes its own single-detection occurrence.

2. **Algorithm `key` derivation does not match Antenna's.** `create_algorithm_reference` falls back to `name.lower().replace(" ", "_").replace("-", "_")`, while Antenna derives keys with `slugify(name)`. Divergent keys for the same model produce duplicate or unmatched algorithm records on import — the exact near-duplicate problem the Antenna side is trying to avoid. Align ADC's key derivation with Antenna's `slugify` (and, longer term, a stable `key + version` identity).

3. **Category maps block classifier imports.** Antenna requires a category map to register a classification algorithm; with `--create-new-algorithms`, importing a classifier whose results carry no category map raises `PipelineNotConfigured` on the Antenna side. Implementing `--include-category-maps` (TODO above) is therefore a prerequisite for importing classifier results into a fresh instance, not just a nice-to-have.

4. **Deployment payload shape.** Antenna#916 expects `DeploymentResponse {id?, name, key?}` on `SourceImageResponse.deployment`; this PR sends `DeploymentReference {name, key}`. The fields line up (Antenna's `id` is optional), but the top-level `PipelineResultsResponse.deployments` list is declared and never populated here — only per-source-image deployments are set. Confirm the import path reads the per-image deployment (it does) or populate the top-level list too, and pin the contract so the two schemas do not drift.

5. **Smaller cleanups.** `MockDetectedObject` is defined inside the per-example loop in `convert_occurrence_to_detection_responses` (hoist it or use a dataclass); the `captures` export still hardcodes `limit=100` per event, which silently truncates a full export.
