### PR TITLE
Add unprocessed image queue option

### DIFF
--- a/trapdata/cli/queue.py
+++ b/trapdata/cli/queue.py
@@ -44,9 +44,25 @@ def all():
 
 
 @cli.command()
+def unprocessed_images():
+    """
+    Queue all images that have not been processed into detections
+    """
+    if not settings.image_base_path:
+        console.print("[red]Error: image_base_path not configured in settings[/red]")
+        raise typer.Exit(1)
+
+    for queue in all_queues(
+        db_path=settings.database_url, base_directory=settings.image_base_path
+    ).values():
+        if isinstance(queue, ImageQueue):
+            queue.add_unprocessed()
+
+
+@cli.command()
 def unprocessed_detections():
     """
-    Add all unprocessed detections to the processing queue.
+    Queue all detections that have not been processed in later steps of the pipeline
     """
     for queue in all_queues(
         db_path=settings.database_url, base_directory=settings.image_base_path


### PR DESCRIPTION
Adds a command line interface option, ami queue unprocessed-images, which queues images that haven't been processed into detections.

This change also adds some updates to the README to describe the commands used to troubleshoot the queue, and to more fully describe the queue in general.

Replaces #87 but uses `main` as the base branch instead of `OOD`