### PR TITLE
Align black config between vscode and pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,10 +9,11 @@ repos:
 
   # Backend hooks
   - repo: https://github.com/psf/black
-    rev: 22.3.0
+    rev: 23.3.0
     hooks:
       - id: black
         types: [file, python]
+        args: ["--line-length=88"]
   - repo: https://github.com/myint/autoflake
     rev: v1.4
     hooks:
@@ -24,18 +25,21 @@ repos:
         types: [file, python]
 
   - repo: https://github.com/pycqa/isort
-    rev: 5.11.5
+    rev: 5.12.0
     hooks:
       - id: isort
         name: isort (python)
+        args: ["--profile", "black", "--line-length=88"]
       - id: isort
         files: .
         name: isort (cython)
         types: [cython]
+        args: ["--profile", "black", "--line-length=88"]
       - id: isort
         files: .
         name: isort (pyi)
         types: [pyi]
+        args: ["--profile", "black", "--line-length=88"]
 
   - repo: https://github.com/pycqa/flake8
     rev: 3.8.3

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,35 +1,33 @@
 {
+  "editor.formatOnSave": true,
+  "editor.codeActionsOnSave": {
+    "source.organizeImports": "explicit",
+    "source.sortImports": "explicit",
+    "source.fixAll.markdownlint": "explicit",
+    "source.fixAll": "explicit"
+  },
+  "files.insertFinalNewline": true,
+  "files.eol": "\n",
+  "files.trimTrailingWhitespace": true,
+  "isort.args": ["--profile", "black", "--line-length=88"],
+  "black-formatter.args": ["--line-length=88"],
+  "[python]": {
     "editor.formatOnSave": true,
-    "editor.codeActionsOnSave": {
-        "source.organizeImports": "explicit",
-        "source.sortImports": "explicit",
-        "source.fixAll.markdownlint": "explicit",
-        "source.fixAll": "explicit"
-    },
-    "files.insertFinalNewline": true,
-    "files.eol": "\n",
-    "files.trimTrailingWhitespace": true,
-    "isort.args": [
-        "--profile",
-        "black"
-    ],
-    "[python]": {
-        "editor.formatOnSave": true,
-        "diffEditor.codeLens": true,
-        "editor.defaultFormatter": "ms-python.black-formatter"
-    },
-    "cSpell.words": [
-        "argmax",
-        "astype",
-        "customise",
-        "fasterrcnn",
-        "kivy",
-        "resnet",
-        "sesh",
-        "sessionmaker",
-        "softmax",
-        "sqlalchemy",
-        "torchvision",
-        "trapdata"
-    ]
+    "diffEditor.codeLens": true,
+    "editor.defaultFormatter": "ms-python.black-formatter"
+  },
+  "cSpell.words": [
+    "argmax",
+    "astype",
+    "customise",
+    "fasterrcnn",
+    "kivy",
+    "resnet",
+    "sesh",
+    "sessionmaker",
+    "softmax",
+    "sqlalchemy",
+    "torchvision",
+    "trapdata"
+  ]
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,7 @@ asyncio_mode = 'auto'
 
 [tool.isort]
 profile = "black"
+line_length = 88
 
 [tool.poetry.scripts]
 trapdata = 'trapdata.ui.main:run'

--- a/trapdata/api/api.py
+++ b/trapdata/api/api.py
@@ -91,7 +91,6 @@ def make_category_map_response(
 def make_algorithm_response(
     model: APIMothDetector | APIMothClassifier,
 ) -> AlgorithmConfigResponse:
-
     category_map = make_category_map_response(model) if model.category_map else None
     return AlgorithmConfigResponse(
         name=model.name,

--- a/trapdata/db/models/__init__.py
+++ b/trapdata/db/models/__init__.py
@@ -1,7 +1,7 @@
-from .events import MonitoringSession
-from .images import TrapImage
-from .detections import DetectedObject
 from . import deployments  # noqa
 from . import occurrences  # noqa
+from .detections import DetectedObject
+from .events import MonitoringSession
+from .images import TrapImage
 
 __models__ = [MonitoringSession, TrapImage, DetectedObject]


### PR DESCRIPTION
Ensuring the same `--profile=black`, `line-length=88` and versions are used across `settings.json`, `pyproject.toml` and pre-commit.yaml`