### PR TITLE
Update how errors are returned in API responses

### DIFF
--- a/trapdata/api/schemas.py
+++ b/trapdata/api/schemas.py
@@ -137,10 +137,16 @@ class SourceImageRequest(pydantic.BaseModel):
 
 
 class SourceImageResponse(pydantic.BaseModel):
+    """Response for a source image, with optional error if processing failed."""
+
     model_config = pydantic.ConfigDict(extra="ignore")
 
     id: str
-    url: str
+    url: str | None = None
+    error: str | None = pydantic.Field(
+        default=None,
+        description="Error message if the image failed to process. None means success.",
+    )
 
 
 class AlgorithmCategoryMapResponse(pydantic.BaseModel):
@@ -342,18 +348,14 @@ class PipelineConfigResponse(pydantic.BaseModel):
     stages: list[PipelineStage] = []
 
 
-class AntennaTaskResultError(pydantic.BaseModel):
-    """Error result for a single Antenna task that failed to process."""
-
-    error: str
-    image_id: str | None = None
-
-
 class AntennaTaskResult(pydantic.BaseModel):
-    """Result for a single Antenna task, either success or error."""
+    """Result for a single Antenna task.
+
+    Check source_images[0].error for failure. If error is None, the task succeeded.
+    """
 
     reply_subject: str | None = None
-    result: PipelineResultsResponse | AntennaTaskResultError
+    result: PipelineResultsResponse
 
 
 class AntennaTaskResults(pydantic.BaseModel):

--- a/trapdata/api/tests/test_worker.py
+++ b/trapdata/api/tests/test_worker.py
@@ -10,11 +10,7 @@ import requests
 import torch
 
 from trapdata.api.datasets import RESTDataset, rest_collate_fn
-from trapdata.api.schemas import (
-    AntennaTaskResult,
-    AntennaTaskResultError,
-    PipelineResultsResponse,
-)
+from trapdata.api.schemas import AntennaTaskResult, PipelineResultsResponse
 from trapdata.cli.worker import _get_jobs, _process_job
 
 # ---------------------------------------------------------------------------
@@ -493,11 +489,12 @@ class TestProcessJob:
         batch_results = mock_post.call_args[0][2]
         # 1 success + 1 failure
         assert len(batch_results) == 2
+        # Find error items by checking source_images[0].error
         error_items = [
-            r for r in batch_results if isinstance(r.result, AntennaTaskResultError)
+            r for r in batch_results if r.result.source_images[0].error is not None
         ]
         assert len(error_items) == 1
-        assert error_items[0].result.error == "404 not found"
+        assert error_items[0].result.source_images[0].error == "404 not found"
         assert error_items[0].reply_subject == "reply_fail"
 
     @patch("trapdata.cli.worker.get_rest_dataloader")


### PR DESCRIPTION
## Summary

Unifies error handling in Antenna task results by embedding errors in `SourceImageResponse` rather than using a separate error type.

## Options Considered

We evaluated three approaches for handling mixed success/error results in batch API responses:

**Option 1: Add `error` to `PipelineResultsResponse`**
- Top-level error field on the pipeline response
- Simple but doesn't identify which specific image failed in multi-image batches

**Option 2: Add `error` to `SourceImageResponse`** ✅ (chosen)
- Error field on the source image that failed
- Clean: errors belong with the thing that failed
- Keeps `PipelineResultsResponse` reusable for other contexts
- Consistent structure for all results

**Option 3: Flat structure for Antenna results**
- Completely flatten the response (no nesting)
- Simpler but loses reusability of `PipelineResultsResponse`

## Changes

- Add optional `error` field to `SourceImageResponse` for indicating image processing failures
- Make `url` optional in `SourceImageResponse` (may be None for failed images)
- Remove `AntennaTaskResultError` - errors now go in `source_images[0].error`
- Simplify `AntennaTaskResult` to always use `PipelineResultsResponse`

**Before:**
```python
class AntennaTaskResult:
    result: PipelineResultsResponse | AntennaTaskResultError  # Union type - awkward to parse
```

**After:**
```python
class AntennaTaskResult:
    result: PipelineResultsResponse  # Always the same type
    # Check result.source_images[0].error is not None for failures
```

## Test plan

- [x] All existing worker tests pass
- [x] `test_handles_failed_items` updated to verify new error pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)