### PR TITLE
fix: Worker should only fetch async jobs

### DIFF
--- a/trapdata/antenna/client.py
+++ b/trapdata/antenna/client.py
@@ -2,7 +2,11 @@
 
 import requests
 
-from trapdata.antenna.schemas import AntennaJobsListResponse, AntennaTaskResult, MLBackend
+from trapdata.antenna.schemas import (
+    AntennaJobsListResponse,
+    AntennaTaskResult,
+    JobDispatchMode,
+)
 from trapdata.api.utils import get_http_session
 from trapdata.common.logs import logger
 
@@ -31,7 +35,7 @@ def get_jobs(
                 "pipeline__slug": pipeline_slug,
                 "ids_only": 1,
                 "incomplete_only": 1,
-                "backend": MLBackend.ASYNC_API,  # Only fetch jobs meant for async processing
+                "dispatch_mode": JobDispatchMode.ASYNC_API,  # Only fetch async_api jobs
             }
 
             resp = session.get(url, params=params, timeout=30)

--- a/trapdata/antenna/schemas.py
+++ b/trapdata/antenna/schemas.py
@@ -86,10 +86,20 @@ class AsyncPipelineRegistrationResponse(pydantic.BaseModel):
         description="ID of the processing service that was created or updated",
     )
 
-class MLBackend(str):
+
+class JobDispatchMode(str):
     """
-    Backend types for ML job execution.
+    How a job dispatches its tasks.
+
+    External processing services should only be concerned with
+    jobs with dispatch_mode=async_api
+
+    Other job types will not have any tasks to fetch from the tasks endpoint and will
+    fail if you try to post results for them.
+
+    This mirrors the JobDispatchMode enum in the Antenna server.
     """
 
+    INTERNAL = "internal"
     SYNC_API = "sync_api"
     ASYNC_API = "async_api"


### PR DESCRIPTION
This pull request introduces a new backend type for machine learning job execution and updates job fetching logic to only retrieve jobs intended for asynchronous processing. 

Modified the `get_jobs` function in `trapdata/antenna/client.py` to filter jobs by the `backend` parameter, ensuring only jobs meant for async processing are fetched (`JobDispatchType.ASYNC_API`).

See corresponding antenna fix: https://github.com/RolnickLab/antenna/pull/1118,  it needs to be merged and deployed before this PR.

Tested against the above PR in antenna. 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced job dispatch modes (internal, sync, async) for labeling job types.
  * Job retrieval now filters to async API jobs by default, making async-processed jobs directly discoverable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->