### PR TITLE
Fix mixed image size crash in rest_collate_fn

### DIFF
--- a/trapdata/antenna/datasets.py
+++ b/trapdata/antenna/datasets.py
@@ -333,7 +333,8 @@ def rest_collate_fn(batch: list[dict]) -> dict:
     Custom collate function that separates failed and successful items.
 
     Returns a dict with:
-        - images: List of image tensors (only present if there are successful items)
+        - images: Stacked tensor when all images share the same shape, or a list
+          of tensors when sizes differ (only present if there are successful items)
         - reply_subjects: List of reply subjects for valid images
         - image_ids: List of image IDs for valid images
         - image_urls: List of image URLs for valid images

--- a/trapdata/antenna/datasets.py
+++ b/trapdata/antenna/datasets.py
@@ -364,8 +364,21 @@ def rest_collate_fn(batch: list[dict]) -> dict:
 
     # Collate successful items
     if successful:
+        image_tensors = [item["image"] for item in successful]
+        # Stack into a single tensor when all images are the same size (fast path).
+        # Fall back to a list of tensors for mixed sizes — the detector handles both
+        # but the list path is slower (individual GPU transfers instead of one bulk copy).
+        # To avoid this, sort source images by resolution or request same-size batches.
+        shapes = {t.shape for t in image_tensors}
+        if len(shapes) > 1:
+            logger.warning(
+                f"Batch contains {len(shapes)} different image sizes: {shapes}. "
+                "Falling back to per-image GPU transfer (slower). "
+                "Consider sorting source images by resolution."
+            )
+        images = torch.stack(image_tensors) if len(shapes) == 1 else image_tensors
         result = {
-            "images": torch.stack([item["image"] for item in successful]),
+            "images": images,
             "reply_subjects": [item["reply_subject"] for item in successful],
             "image_ids": [item["image_id"] for item in successful],
             "image_urls": [item.get("image_url") for item in successful],

--- a/trapdata/tests/test_collate.py
+++ b/trapdata/tests/test_collate.py
@@ -78,6 +78,8 @@ class TestRestCollateFnMixedSizes:
         assert result["reply_subjects"] == ["r1", "r2"]
 
     def test_warns_on_mixed_sizes(self, capsys):
+        # capsys (not caplog) because structlog writes to stdout, bypassing
+        # the stdlib logging handler that caplog captures.
         batch = [
             _make_item(h=100, w=200, image_id="a"),
             _make_item(h=300, w=400, image_id="b"),

--- a/trapdata/tests/test_collate.py
+++ b/trapdata/tests/test_collate.py
@@ -1,0 +1,126 @@
+"""Tests for rest_collate_fn in trapdata.antenna.datasets."""
+
+import torch
+
+from trapdata.antenna.datasets import rest_collate_fn
+
+
+def _make_item(h=224, w=224, image_id="img1", reply_subject="reply1", error=None):
+    """Helper to create a batch item dict."""
+    item = {
+        "image": None if error else torch.rand(3, h, w),
+        "image_id": image_id,
+        "reply_subject": reply_subject,
+        "image_url": f"http://example.com/{image_id}.jpg",
+    }
+    if error:
+        item["error"] = error
+    return item
+
+
+class TestRestCollateFnSameSize:
+    """When all images are the same size, output should be a stacked tensor."""
+
+    def test_single_image(self):
+        batch = [_make_item(h=100, w=200)]
+        result = rest_collate_fn(batch)
+        assert isinstance(result["images"], torch.Tensor)
+        assert result["images"].shape == (1, 3, 100, 200)
+
+    def test_multiple_same_size(self):
+        batch = [_make_item(h=100, w=200, image_id=f"img{i}") for i in range(4)]
+        result = rest_collate_fn(batch)
+        assert isinstance(result["images"], torch.Tensor)
+        assert result["images"].shape == (4, 3, 100, 200)
+
+    def test_metadata_preserved(self):
+        batch = [
+            _make_item(image_id="a", reply_subject="r1"),
+            _make_item(image_id="b", reply_subject="r2"),
+        ]
+        result = rest_collate_fn(batch)
+        assert result["image_ids"] == ["a", "b"]
+        assert result["reply_subjects"] == ["r1", "r2"]
+        assert len(result["image_urls"]) == 2
+
+
+class TestRestCollateFnMixedSizes:
+    """When images have different sizes, output should be a list of tensors."""
+
+    def test_two_different_sizes(self):
+        batch = [
+            _make_item(h=2160, w=4096, image_id="big"),
+            _make_item(h=2464, w=3280, image_id="small"),
+        ]
+        result = rest_collate_fn(batch)
+        assert isinstance(result["images"], list)
+        assert len(result["images"]) == 2
+        assert result["images"][0].shape == (3, 2160, 4096)
+        assert result["images"][1].shape == (3, 2464, 3280)
+
+    def test_three_different_sizes(self):
+        batch = [
+            _make_item(h=100, w=200, image_id="a"),
+            _make_item(h=300, w=400, image_id="b"),
+            _make_item(h=500, w=600, image_id="c"),
+        ]
+        result = rest_collate_fn(batch)
+        assert isinstance(result["images"], list)
+        assert len(result["images"]) == 3
+
+    def test_metadata_preserved(self):
+        batch = [
+            _make_item(h=100, w=200, image_id="a", reply_subject="r1"),
+            _make_item(h=300, w=400, image_id="b", reply_subject="r2"),
+        ]
+        result = rest_collate_fn(batch)
+        assert result["image_ids"] == ["a", "b"]
+        assert result["reply_subjects"] == ["r1", "r2"]
+
+    def test_warns_on_mixed_sizes(self, capsys):
+        batch = [
+            _make_item(h=100, w=200, image_id="a"),
+            _make_item(h=300, w=400, image_id="b"),
+        ]
+        rest_collate_fn(batch)
+        captured = capsys.readouterr()
+        assert "different image sizes" in captured.out
+
+
+class TestRestCollateFnFailedItems:
+    """Failed items (image=None or error set) should be separated out."""
+
+    def test_all_failed(self):
+        batch = [
+            _make_item(error="download failed", image_id="a"),
+            _make_item(error="timeout", image_id="b"),
+        ]
+        result = rest_collate_fn(batch)
+        assert "images" not in result
+        assert result["reply_subjects"] == []
+        assert result["image_ids"] == []
+        assert len(result["failed_items"]) == 2
+
+    def test_mixed_success_and_failure(self):
+        batch = [
+            _make_item(h=224, w=224, image_id="ok"),
+            _make_item(error="bad url", image_id="fail"),
+        ]
+        result = rest_collate_fn(batch)
+        assert isinstance(result["images"], torch.Tensor)
+        assert result["images"].shape == (1, 3, 224, 224)
+        assert result["image_ids"] == ["ok"]
+        assert len(result["failed_items"]) == 1
+        assert result["failed_items"][0]["image_id"] == "fail"
+
+    def test_mixed_sizes_with_failure(self):
+        batch = [
+            _make_item(h=100, w=200, image_id="a"),
+            _make_item(error="oops", image_id="b"),
+            _make_item(h=300, w=400, image_id="c"),
+        ]
+        result = rest_collate_fn(batch)
+        # Two successful images with different sizes → list
+        assert isinstance(result["images"], list)
+        assert len(result["images"]) == 2
+        assert len(result["failed_items"]) == 1

--- a/trapdata/tests/test_collate.py
+++ b/trapdata/tests/test_collate.py
@@ -49,14 +49,14 @@ class TestRestCollateFnMixedSizes:
 
     def test_two_different_sizes(self):
         batch = [
-            _make_item(h=2160, w=4096, image_id="big"),
-            _make_item(h=2464, w=3280, image_id="small"),
+            _make_item(h=10, w=11, image_id="big"),
+            _make_item(h=12, w=13, image_id="small"),
         ]
         result = rest_collate_fn(batch)
         assert isinstance(result["images"], list)
         assert len(result["images"]) == 2
-        assert result["images"][0].shape == (3, 2160, 4096)
-        assert result["images"][1].shape == (3, 2464, 3280)
+        assert result["images"][0].shape == (3, 10, 11)
+        assert result["images"][1].shape == (3, 12, 13)
 
     def test_three_different_sizes(self):
         batch = [


### PR DESCRIPTION
## Summary
- `torch.stack` in `rest_collate_fn` crashes when a batch contains images of different resolutions (e.g. 2160x4096 vs 2464x3280)
- Fall back to a list of tensors for mixed-size batches — `predict_batch` already handles both formats
- Log a warning when the slow path is hit, suggesting sorting source images by resolution

## Test plan
- [x] 10 unit tests added covering same-size stacking, mixed-size fallback, metadata, warnings, and failure cases
- [x] Verified on a live job with mixed-resolution images — warnings appear and processing completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Image batching now detects uniform image dimensions: matching images are stacked into a single tensor for efficiency; mixed-size images are returned as a list and trigger a warning about per-image GPU transfers.

* **Tests**
  * Added comprehensive tests covering stacked vs. list behavior, mixed sizes warning, and handling of failed/missing items during collation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->