### PR TITLE
Make DataLoader tuning knobs configurable via env (#138)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,5 +13,42 @@ AMI_NUM_WORKERS=1
 # See: https://github.com/RolnickLab/antenna
 AMI_ANTENNA_API_BASE_URL=http://localhost:8000/api/v2
 AMI_ANTENNA_API_AUTH_TOKEN=your_antenna_auth_token_here
-AMI_ANTENNA_API_BATCH_SIZE=4
 AMI_ANTENNA_SERVICE_NAME="AMI Data Companion"
+
+# Tasks per POST fetch from /api/v2/jobs/{id}/tasks/. This is the single
+# biggest lever on peak worker RAM — every fetched task gets downloaded and
+# decoded into a ~144 MB float32 tensor (for a 4K JPEG) or ~9 MB (for a
+# typical 1.5 MB JPEG). Peak ingest RAM ≈
+#   AMI_ANTENNA_API_BATCH_SIZE × prefetch_factor × avg_tensor_bytes × (2 if pin_memory else 1)
+#
+# Rough guidance (please validate for your own workload):
+#   - typical ~1.5 MB JPEGs on a 22 GB worker: 24 appears to work
+#   - large ~24 MB JPEGs on a 22 GB worker: try 2
+#   - large ~24 MB JPEGs on a 70 GB worker: try 8–16
+#
+# Note: AMI_LOCALIZATION_BATCH_SIZE and AMI_CLASSIFICATION_BATCH_SIZE only
+# control model inference batch size, not ingest memory. This is the knob
+# you probably want. See: issue #138.
+AMI_ANTENNA_API_BATCH_SIZE=4
+
+# DataLoader tuning (defaults preserve current behavior). See issue #138.
+#
+# pin_memory=True locks prefetched tensors in non-swappable system RAM so
+# CUDA can DMA them to GPU without an extra copy. Helps when CPU→GPU
+# transfer is a meaningful fraction of wall-clock time. Hurts when data
+# loading dominates wall time (e.g. HTTP-sourced images) because the
+# memory cost is real but the speedup is ~0. Does NOT affect VRAM.
+# AMI_ANTENNA_API_DATALOADER_PIN_MEMORY=true
+
+# prefetch_factor is the number of batches each DataLoader subprocess
+# keeps queued ahead of the main process. Helps hide data-loading latency
+# when network or decode is slow. Scales peak RAM linearly — raising it
+# multiplies the memory cost of every in-flight tensor.
+# AMI_ANTENNA_API_DATALOADER_PREFETCH_FACTOR=4
+
+# Concurrent HTTP downloads per DataLoader subprocess.
+# AMI_ANTENNA_API_DATALOADER_DOWNLOAD_THREADS=8
+
+# Worker loop tuning
+# AMI_ANTENNA_MAX_PENDING_POSTS=5
+# AMI_ANTENNA_IDLE_SLEEP_SECONDS=5

--- a/README.md
+++ b/README.md
@@ -281,6 +281,36 @@ The worker will:
 
 For more information, see the [Antenna platform documentation](https://github.com/RolnickLab/antenna).
 
+### Tuning for memory-constrained or large-image workloads
+
+If your worker is OOM-killed or runs out of memory on jobs with large source images, the knob you probably want is **`AMI_ANTENNA_API_BATCH_SIZE`** — not `AMI_LOCALIZATION_BATCH_SIZE` or `AMI_CLASSIFICATION_BATCH_SIZE`, which only control model inference batch size and do not limit how much image data is loaded into RAM.
+
+Peak ingest RAM per AMI worker roughly scales as:
+
+```
+AMI_ANTENNA_API_BATCH_SIZE
+  × AMI_ANTENNA_API_DATALOADER_PREFETCH_FACTOR (default 4)
+  × avg decoded image tensor size
+  × (2 if AMI_ANTENNA_API_DATALOADER_PIN_MEMORY else 1)
+  × AMI_NUM_WORKERS
+```
+
+A 24 MB JPEG decodes to ~144 MB as a `float32` tensor; a typical ~1.5 MB JPEG decodes to ~9 MB. So the same settings that work fine on normal jobs can explode on a batch of large images.
+
+Rough starting points (please validate for your own workload):
+
+| Worker RAM | Typical (~1.5 MB) images | Large (~24 MB) images |
+|---|---|---|
+| 22 GB | `AMI_ANTENNA_API_BATCH_SIZE=24` | `AMI_ANTENNA_API_BATCH_SIZE=2` |
+| 35 GB | `AMI_ANTENNA_API_BATCH_SIZE=24` | `AMI_ANTENNA_API_BATCH_SIZE=8` |
+| 70 GB | `AMI_ANTENNA_API_BATCH_SIZE=24` | `AMI_ANTENNA_API_BATCH_SIZE=16` |
+
+For HTTP-sourced workloads where download dominates wall time (the common case for the Antenna worker), you can also set `AMI_ANTENNA_API_DATALOADER_PIN_MEMORY=false` to roughly halve peak RAM with no throughput cost. Prefetching is still useful to hide network latency, so keep `AMI_ANTENNA_API_DATALOADER_PREFETCH_FACTOR` at its default unless RAM is very tight.
+
+See issue [#138](https://github.com/RolnickLab/ami-data-companion/issues/138) for the detailed memory analysis, flow diagram in `trapdata/antenna/datasets.py`, and proposed auto-tuning directions.
+
+**Deployment note — file descriptor limit**: when running the worker under `supervisord` or `systemd`, set the soft file-descriptor limit to at least 65536. The default on many distros (Debian, Ubuntu) is 1024, which the worker can legitimately exceed during DataLoader startup (IPC pipes + SSL sockets + concurrent downloads), causing an unrelated `OSError: [Errno 24] Too many open files` crash that looks like a leak but isn't. For `supervisord`, add `minfds=65536` under `[supervisord]` in `/etc/supervisor/supervisord.conf`. For `systemd`, add `LimitNOFILE=65536` to the unit file.
+
 ## Web UI demo (Gradio)
 
 A simple web UI is also available to test the inference pipeline. This is a quick way to test models on a remote server via a web browser.

--- a/trapdata/antenna/datasets.py
+++ b/trapdata/antenna/datasets.py
@@ -9,58 +9,121 @@ different setting and targets a different bottleneck.
 ::
 
     ┌──────────────────────────────────────────────────────────────────┐
-    │  GPU process  (_worker_loop in worker.py)                       │
-    │  One per GPU. Runs detection → classification on batches.       │
-    │  Controlled by: automatic (one per torch.cuda.device_count())   │
+    │  GPU process  (_worker_loop in worker.py)                        │
+    │  One per GPU. Runs detection → classification on batches.        │
+    │  Controlled by: automatic (one per torch.cuda.device_count())    │
     ├──────────────────────────────────────────────────────────────────┤
     │  DataLoader workers  (num_workers subprocesses)                  │
-    │  Each subprocess runs its own RESTDataset.__iter__ loop:        │
+    │  Each subprocess runs its own RESTDataset.__iter__ loop:         │
     │    1. POST /tasks  → fetch batch of task metadata from Antenna   │
-    │    2. Download images (threaded, see below)                     │
-    │    3. Yield individual (image_tensor, metadata) rows            │
-    │  The DataLoader collates rows into GPU-sized batches.           │
-    │  Controlled by: settings.num_workers  (AMI_NUM_WORKERS)         │
-    │  Default: 2.  Safe >0 because Antenna dequeues atomically.      │
+    │    2. Download images (threaded, see below)                      │
+    │    3. Yield individual (image_tensor, metadata) rows             │
+    │  The DataLoader collates rows into GPU-sized batches.            │
+    │  Controlled by: settings.num_workers  (AMI_NUM_WORKERS)          │
+    │  Safe >0 because Antenna dequeues atomically.                    │
     ├──────────────────────────────────────────────────────────────────┤
     │  Thread pool  (ThreadPoolExecutor inside each DataLoader worker) │
     │  Downloads images concurrently *within* one API fetch batch.    │
-    │  Each thread: HTTP GET → PIL open → RGB convert → ToTensor().   │
-    │  Controlled by: ThreadPoolExecutor(max_workers=8) on the class. │
-    │  Note: RGB conversion and ToTensor are GIL-bound (CPU). Only    │
-    │  the network wait truly runs in parallel. A future optimisation  │
-    │  could move transforms out of the thread.                       │
+    │  Each thread: HTTP GET → PIL open → RGB convert → ToTensor().    │
+    │  Controlled by: AMI_ANTENNA_API_DATALOADER_DOWNLOAD_THREADS (8). │
+    │  Note: RGB conversion and ToTensor are GIL-bound (CPU). Only     │
+    │  the network wait truly runs in parallel.                        │
     └──────────────────────────────────────────────────────────────────┘
+
+Request and memory flow (per DataLoader subprocess, one job)
+============================================================
+
+This is the flow that drives peak RAM. See issue #138 for the full analysis.
+
+::
+
+    ┌─ RESTDataset.__iter__ ────────────────────────────────────────────┐
+    │                                                                    │
+    │  loop until no more tasks:                                         │
+    │                                                                    │
+    │    ┌─ _fetch_tasks() ──────────────────────────────────────────┐   │
+    │    │  POST /api/v2/jobs/{id}/tasks/                            │   │
+    │    │  body: {"batch_size": AMI_ANTENNA_API_BATCH_SIZE}         │   │
+    │    │  → returns up to N task dicts (image_url + metadata)      │   │
+    │    └───────────────────────────────────────────────────────────┘   │
+    │                              │                                    │
+    │                              ▼                                    │
+    │    ┌─ _load_images_threaded() ────────────────────────────────┐   │
+    │    │  ThreadPoolExecutor(DOWNLOAD_THREADS) downloads N JPEGs  │   │
+    │    │  Each thread: HTTP GET → PIL decode → ToTensor (float32) │   │
+    │    │                                                           │   │
+    │    │  RAM cost at this point: N × tensor_size                 │   │
+    │    │    where tensor_size ≈ 4 × decoded_bytes                 │   │
+    │    │    (24 MB JPEG → ~144 MB float32 CHW tensor)             │   │
+    │    └───────────────────────────────────────────────────────────┘   │
+    │                              │                                    │
+    │                              ▼                                    │
+    │    yield N rows → collated into a batch of size N                 │
+    │                              │                                    │
+    └──────────────────────────────┼─────────────────────────────────────┘
+                                   │
+                                   ▼
+    ┌─ DataLoader queue (per subprocess) ────────────────────────────────┐
+    │  Holds up to PREFETCH_FACTOR batches ready for the main process.   │
+    │                                                                     │
+    │  If AMI_ANTENNA_API_DATALOADER_PIN_MEMORY=True:                    │
+    │    Each queued batch is also in pinned (unswappable) shmem for IPC │
+    │    → effective cost ≈ 2× (pageable + pinned copy)                  │
+    │                                                                     │
+    │  Peak ingest RAM per subprocess ≈                                   │
+    │    PREFETCH_FACTOR × API_BATCH_SIZE × tensor_size × (2 if pinned)  │
+    │                                                                     │
+    │  Total across worker = above × num_workers + 1 active batch on GPU │
+    └─────────────────────────────────────────────────────────────────────┘
+
+When peak RAM is the problem, the knob that scales the hardest is
+AMI_ANTENNA_API_BATCH_SIZE. Turning off AMI_ANTENNA_API_DATALOADER_PIN_MEMORY
+roughly halves the cost on HTTP-sourced workloads (where the pinned-memory
+DMA speedup is negligible compared to download time). Lowering
+AMI_ANTENNA_API_DATALOADER_PREFETCH_FACTOR trades network-latency hiding
+for lower peak RAM.
 
 Settings quick-reference (prefix with AMI_ as env vars):
 
     localization_batch_size  (default 8)
         How many images the GPU processes at once (detection). Larger =
-        more GPU memory. These are full-resolution images (~4K).
-        Async worker use antennna_api_batch_size for this.
+        more VRAM. These are full-resolution images.
+        This is a model-side knob — does NOT limit ingest RAM.
+
+    classification_batch_size  (default 20)
+        How many crops the classifier processes at once. Model-side.
 
     num_workers  (default 4)
-        DataLoader subprocesses. Each independently fetches tasks and
-        downloads images. More workers = more images prefetched for the
-        GPU, at the cost of CPU/RAM. With 0 workers, fetching and
-        inference are sequential (useful for debugging).
+        DataLoader subprocesses per AMI worker instance. Each independently
+        fetches tasks and downloads images. More workers = more images
+        prefetched, at the cost of CPU/RAM. 0 makes fetching and inference
+        sequential (useful for debugging).
 
-    antenna_api_batch_size  (default 16)
-        How many task URLs to request from Antenna per API call.
-        Determines how many images are downloaded concurrently per
-        thread pool invocation. Should be >= localization_batch_size
-        so one API call can fill at least one GPU batch without an
-        extra round trip.
+    antenna_api_batch_size  (default 24)
+        Tasks requested per POST to /api/v2/jobs/{id}/tasks/. The biggest
+        lever on peak ingest RAM. See the flow diagram above.
 
-    prefetch_factor  (PyTorch default: 2 when num_workers > 0)
-        Batches prefetched per worker. Not overridden here — the
-        default was tested and no improvement was measured by
-        increasing it (it just adds memory pressure).
+    antenna_api_dataloader_pin_memory  (default True)
+        Whether the DataLoader puts prefetched tensors in page-locked system
+        RAM. Helpful when CPU→GPU transfer is a meaningful fraction of wall
+        time, harmful when data loading dominates wall time. Affects system
+        RAM, NOT VRAM.
 
-What has NOT been benchmarked yet (as of 2026-02):
+    antenna_api_dataloader_prefetch_factor  (default 4)
+        Batches each DataLoader subprocess keeps queued ahead of the main
+        process. Hides data-loading latency; multiplies peak RAM.
+
+    antenna_api_dataloader_download_threads  (default 8)
+        ThreadPoolExecutor size for concurrent image downloads inside one
+        DataLoader subprocess.
+
+What has NOT been benchmarked yet:
     - Optimal num_workers / thread count combination
     - Whether moving transforms out of threads helps throughput
-    - Whether multiple DataLoader workers + threads overlap well
-      or contend on the GIL
+    - Whether multiple DataLoader workers + threads overlap well or
+      contend on the GIL
+    - Actual memory profile under a memory profiler (the numbers in
+      issue #138 are estimates from code reading, not measurements)
 """
 
 import typing
@@ -110,6 +173,7 @@ class RESTDataset(torch.utils.data.IterableDataset):
         job_id: int,
         batch_size: int = 1,
         image_transforms: torchvision.transforms.Compose | None = None,
+        download_threads: int = 8,
     ):
         """
         Initialize the REST dataset.
@@ -120,6 +184,7 @@ class RESTDataset(torch.utils.data.IterableDataset):
             job_id: The job ID to fetch tasks for
             batch_size: Number of tasks to request per batch
             image_transforms: Optional transforms to apply to loaded images
+            download_threads: ThreadPoolExecutor size for concurrent image downloads
         """
         super().__init__()
         self.base_url = base_url
@@ -127,6 +192,7 @@ class RESTDataset(torch.utils.data.IterableDataset):
         self.job_id = job_id
         self.batch_size = batch_size
         self.image_transforms = image_transforms or torchvision.transforms.ToTensor()
+        self.download_threads = download_threads
 
         # These are created lazily in _ensure_sessions() because they contain
         # unpicklable objects (ThreadPoolExecutor has a SimpleQueue) and
@@ -147,7 +213,7 @@ class RESTDataset(torch.utils.data.IterableDataset):
         if self._image_fetch_session is None:
             self._image_fetch_session = get_http_session()
         if self._executor is None:
-            self._executor = ThreadPoolExecutor(max_workers=8)
+            self._executor = ThreadPoolExecutor(max_workers=self.download_threads)
 
     def __del__(self):
         """Clean up HTTP sessions and thread pool on dataset destruction."""
@@ -421,14 +487,18 @@ def get_rest_dataloader(
         job_id: Job ID to fetch tasks for
         settings: Settings object. Relevant fields:
             - antenna_api_base_url / antenna_api_auth_token
-            - antenna_api_batch_size  (tasks per API call and GPU batch size)
-            - num_workers            (DataLoader subprocesses)
+            - antenna_api_batch_size                  (tasks per API call)
+            - num_workers                             (DataLoader subprocesses)
+            - antenna_api_dataloader_pin_memory       (see issue #138)
+            - antenna_api_dataloader_prefetch_factor  (see issue #138)
+            - antenna_api_dataloader_download_threads (per-subprocess HTTP pool)
     """
     dataset = RESTDataset(
         base_url=settings.antenna_api_base_url,
         auth_token=settings.antenna_api_auth_token,
         job_id=job_id,
         batch_size=settings.antenna_api_batch_size,
+        download_threads=settings.antenna_api_dataloader_download_threads,
     )
 
     return torch.utils.data.DataLoader(
@@ -436,9 +506,13 @@ def get_rest_dataloader(
         batch_size=1,  # We collate manually in rest_collate_fn, so set batch_size=1 here
         num_workers=settings.num_workers,
         collate_fn=_no_op_collate_fn,
-        pin_memory=True,
+        pin_memory=settings.antenna_api_dataloader_pin_memory,
         persistent_workers=settings.num_workers > 0,
-        prefetch_factor=4 if settings.num_workers > 0 else None,
+        prefetch_factor=(
+            settings.antenna_api_dataloader_prefetch_factor
+            if settings.num_workers > 0
+            else None
+        ),
     )
 
 

--- a/trapdata/antenna/worker.py
+++ b/trapdata/antenna/worker.py
@@ -26,6 +26,9 @@ from trapdata.common.logs import logger
 from trapdata.common.utils import log_time
 from trapdata.settings import Settings, read_settings
 
+# Default values — operators can override via settings (AMI_ANTENNA_MAX_PENDING_POSTS,
+# AMI_ANTENNA_IDLE_SLEEP_SECONDS). These module-level constants are kept for
+# backward compatibility with any external imports.
 MAX_PENDING_POSTS = 5  # Maximum number of concurrent result posts before blocking
 SLEEP_TIME_SECONDS = 5
 
@@ -124,9 +127,9 @@ def _worker_loop(gpu_id: int, pipelines: list[str]):
 
         if not any_jobs:
             logger.info(
-                f"[GPU {gpu_id}] No jobs found, sleeping for {SLEEP_TIME_SECONDS} seconds"
+                f"[GPU {gpu_id}] No jobs found, sleeping for {settings.antenna_idle_sleep_seconds} seconds"
             )
-            time.sleep(SLEEP_TIME_SECONDS)
+            time.sleep(settings.antenna_idle_sleep_seconds)
 
 
 def _apply_binary_classification(

--- a/trapdata/settings.py
+++ b/trapdata/settings.py
@@ -43,6 +43,18 @@ class Settings(BaseSettings):
     antenna_service_name: str = "AMI Data Companion"
     antenna_api_batch_size: int = 24
 
+    # DataLoader tuning — previously hardcoded in trapdata/antenna/datasets.py.
+    # See issue #138 for the memory-scaling analysis. Defaults preserve prior
+    # behavior; lower pin_memory and/or prefetch_factor when per-image size is
+    # large relative to worker RAM.
+    antenna_api_dataloader_pin_memory: bool = True
+    antenna_api_dataloader_prefetch_factor: int = 4
+    antenna_api_dataloader_download_threads: int = 8
+
+    # Worker loop tuning — previously hardcoded in trapdata/antenna/worker.py.
+    antenna_max_pending_posts: int = 5
+    antenna_idle_sleep_seconds: int = 5
+
     @pydantic.field_validator("image_base_path", "user_data_path")
     def validate_path(cls, v):
         """


### PR DESCRIPTION
## Summary

Implements Direction 2 from issue #138 — exposes the previously-hardcoded DataLoader and worker loop values as pydantic Settings fields, with current values as defaults so there is no behavior change on upgrade.

Also documents \`AMI_ANTENNA_API_BATCH_SIZE\` (the existing but undocumented knob that appears to be the biggest lever on peak ingest memory) in \`.env.example\` and the README, and adds a request-and-memory flow diagram to the \`datasets.py\` module docstring.

This PR is deliberately **no behavior change by default**. Every new setting defaults to its current hardcoded value. Operators who want to tune just set env vars.

## New settings

| Env var | Default | Previously hardcoded at |
|---|---|---|
| \`AMI_ANTENNA_API_DATALOADER_PIN_MEMORY\` | \`true\` | \`datasets.py::get_rest_dataloader\` |
| \`AMI_ANTENNA_API_DATALOADER_PREFETCH_FACTOR\` | \`4\` | \`datasets.py::get_rest_dataloader\` |
| \`AMI_ANTENNA_API_DATALOADER_DOWNLOAD_THREADS\` | \`8\` | \`datasets.py::RESTDataset._ensure_sessions\` |
| \`AMI_ANTENNA_MAX_PENDING_POSTS\` | \`5\` | \`worker.py::MAX_PENDING_POSTS\` |
| \`AMI_ANTENNA_IDLE_SLEEP_SECONDS\` | \`5\` | \`worker.py::SLEEP_TIME_SECONDS\` |

The existing module-level \`MAX_PENDING_POSTS\` and \`SLEEP_TIME_SECONDS\` constants in \`worker.py\` are kept as-is for backward compatibility with any external imports; the runtime code now reads from settings.

## Documentation changes

- **\`.env.example\`**: adds commented-out entries for every new knob with tradeoff notes. Adds a memory-scaling formula and rough per-worker-RAM guidance for \`AMI_ANTENNA_API_BATCH_SIZE\`. Calls out explicitly that \`AMI_LOCALIZATION_BATCH_SIZE\` / \`AMI_CLASSIFICATION_BATCH_SIZE\` do **not** limit ingest memory — a common confusion.
- **\`README.md\`**: adds a "Tuning for memory-constrained or large-image workloads" section under "Running the Antenna Worker" with the peak-RAM formula, per-RAM-size starting points, and a deployment note about the supervisor/systemd soft FD limit (the default 1024 is too low for the worker's real FD working set and causes a confusing \`OSError: [Errno 24]\` at startup).
- **\`datasets.py\`** module docstring: adds an ASCII flow diagram showing the per-subprocess request → download → tensor → prefetch queue path and where each env var applies. Also corrects a couple of stale values in the existing quick-reference (default \`antenna_api_batch_size\` is 24, not 16; \`prefetch_factor\` is explicitly set to 4, not "PyTorch default").

## What's NOT in this PR

Intentionally scoped small:

- **Default changes** — I did not change any default value. If we want \`pin_memory=False\` to be the new default for HTTP-sourced workloads (which the analysis in #138 suggests is probably correct), that's a separate PR after a small-image throughput regression test.
- **The tuning command** (Direction 3 in #138) — a separate small feature.
- **Probe-based auto-tune** (Direction 4 in #138) — a larger refactor of \`_process_job\` to rebuild the DataLoader per job based on a probe of the first few tasks.
- **Disk-based prefetch** (Direction 5 in #138) — an architectural refactor that deserves its own design discussion.

## Testing

- \`AMI_ANTENNA_API_DATALOADER_PIN_MEMORY=false\`, \`AMI_ANTENNA_API_DATALOADER_PREFETCH_FACTOR=1\`, and \`AMI_ANTENNA_API_BATCH_SIZE=4\` were applied as a hot patch on a test worker processing a job with ~914 source images at ~24 MB per JPEG. Worker ran stably at ~13 GB RSS on a 68 GB instance, ~2 s/image, across multiple consecutive jobs. Without any of those changes the same worker OOM-killed at ~68 GB in ~40 seconds.
- Pre-commit hooks pass (black, isort, flake8, autoflake, trailing whitespace, EOF).
- **Not yet done**: isolated ablation — the one deployment had all three changes at once, so we haven't proven that \`AMI_ANTENNA_API_BATCH_SIZE=4\` alone is sufficient. See the "what we still need to verify" section of #138. Once this PR lands, that test is just setting one env var and becomes trivial.

## Base branch

This PR targets \`feature/uv-migration\` because that's the branch currently used in our deployment. Once \`feature/uv-migration\` merges to main, GitHub will auto-retarget this PR.

Closes none of #138 (this is one direction of several — the issue stays open).


## Follow-up TODOs (before merge or as separate issues)

- [ ] **Isolated ablation to prove the config-only fix is sufficient.** With this PR deployed, set `AMI_ANTENNA_API_BATCH_SIZE=8` only (leaving `AMI_ANTENNA_API_DATALOADER_PIN_MEMORY` at its default `true` and `PREFETCH_FACTOR` at `4`) on a small-RAM worker, and run a large-image job. If it completes without OOM, the minimal fix is just the one env var and we can recommend that as the universal guidance. If it OOMs, we know `pin_memory=false` is actually load-bearing and should probably become the new default for HTTP-sourced workloads (separate PR). Cheap to run: one env edit and a worker restart.
- [ ] **Small-image regression test.** Run a typical ~1.5 MB JPEG job with `AMI_ANTENNA_API_DATALOADER_PIN_MEMORY=false` and compare throughput against the current defaults. If throughput is within noise, `pin_memory=false` is probably the right new default for this worker.
- [ ] **Memray / tracemalloc profile** of a large-image job to replace the estimated numbers in the tables with measured ones. Would also catch any residual leak on top of the steady-state peak.
- [ ] Once `feature/uv-migration` merges to main, re-target this PR.