### PR TITLE
feat(antenna): receive and echo pipeline config from NATS tasks

### DIFF
--- a/trapdata/antenna/datasets.py
+++ b/trapdata/antenna/datasets.py
@@ -310,6 +310,7 @@ class RESTDataset(torch.utils.data.IterableDataset):
                         "reply_subject": task.reply_subject,
                         "image_id": task.image_id,
                         "image_url": task.image_url,
+                        "config": task.config,
                     }
                     if errors:
                         row["error"] = "; ".join(errors) if errors else None
@@ -380,12 +381,15 @@ def rest_collate_fn(batch: list[dict]) -> dict:
             "reply_subjects": [item["reply_subject"] for item in successful],
             "image_ids": [item["image_id"] for item in successful],
             "image_urls": [item.get("image_url") for item in successful],
+            # All tasks in a job share the same pipeline config; take the first.
+            "config": successful[0].get("config"),
         }
     else:
         # Empty batch - all failed
         result = {
             "reply_subjects": [],
             "image_ids": [],
+            "config": None,
         }
 
     result["failed_items"] = failed

--- a/trapdata/antenna/schemas.py
+++ b/trapdata/antenna/schemas.py
@@ -16,9 +16,10 @@ class AntennaPipelineProcessingTask(pydantic.BaseModel):
     image_id: str
     image_url: str
     reply_subject: str | None = None  # The NATS subject to send the result to
-    # TODO: Do we need these?
+    config: dict | None = (
+        None  # Pipeline config from Antenna (see PipelineRequest.config)
+    )
     # detections: list[DetectionRequest] | None = None
-    # config: PipelineRequestConfigParameters | dict | None = None
 
 
 class AntennaJobListItem(pydantic.BaseModel):

--- a/trapdata/antenna/schemas.py
+++ b/trapdata/antenna/schemas.py
@@ -2,7 +2,11 @@
 
 import pydantic
 
-from trapdata.api.schemas import PipelineConfigResponse, PipelineResultsResponse
+from trapdata.api.schemas import (
+    PipelineConfigRequest,
+    PipelineConfigResponse,
+    PipelineResultsResponse,
+)
 
 # @TODO move more schemas here that are Antenna-specific from api/schemas.py
 
@@ -16,7 +20,7 @@ class AntennaPipelineProcessingTask(pydantic.BaseModel):
     image_id: str
     image_url: str
     reply_subject: str | None = None  # The NATS subject to send the result to
-    config: dict | None = (
+    config: PipelineConfigRequest | None = (
         None  # Pipeline config from Antenna (see PipelineRequest.config)
     )
     # detections: list[DetectionRequest] | None = None

--- a/trapdata/antenna/worker.py
+++ b/trapdata/antenna/worker.py
@@ -19,6 +19,7 @@ from trapdata.api.models.classification import MothClassifierBinary
 from trapdata.api.models.localization import APIMothDetector
 from trapdata.api.schemas import (
     DetectionResponse,
+    PipelineConfigRequest,
     PipelineResultsResponse,
     SourceImageResponse,
 )
@@ -208,6 +209,7 @@ def _process_batch(
     pipeline: str,
     binary_filter: "MothClassifierBinary | None",
     use_binary_filter: bool,
+    pipeline_config: dict | None = None,
 ) -> tuple[int, int, list[AntennaTaskResult], float, float]:
     """Process a single batch of images through detection and classification.
 
@@ -223,6 +225,7 @@ def _process_batch(
         pipeline: Pipeline slug for response payload
         binary_filter: Binary moth/non-moth classifier, or None
         use_binary_filter: Whether to run binary classification step
+        pipeline_config: Config dict received from Antenna task (may be None)
 
     Returns:
         (n_items, n_detections, batch_results, detect_time, classify_time)
@@ -351,6 +354,7 @@ def _process_batch(
                 source_images=[source_image],
                 detections=image_detections[image_id],
                 total_time=batch_elapsed / len(image_ids),
+                config=PipelineConfigRequest(**(pipeline_config or {})),
             )
             batch_results.append(
                 AntennaTaskResult(
@@ -491,6 +495,7 @@ def _process_job(
                 pipeline,
                 binary_filter,
                 use_binary_filter,
+                pipeline_config=batch.get("config"),
             )
             items += n_items
             total_detections += n_detections

--- a/trapdata/antenna/worker.py
+++ b/trapdata/antenna/worker.py
@@ -209,7 +209,7 @@ def _process_batch(
     pipeline: str,
     binary_filter: "MothClassifierBinary | None",
     use_binary_filter: bool,
-    pipeline_config: dict | None = None,
+    pipeline_config: PipelineConfigRequest | None = None,
 ) -> tuple[int, int, list[AntennaTaskResult], float, float]:
     """Process a single batch of images through detection and classification.
 
@@ -225,7 +225,7 @@ def _process_batch(
         pipeline: Pipeline slug for response payload
         binary_filter: Binary moth/non-moth classifier, or None
         use_binary_filter: Whether to run binary classification step
-        pipeline_config: Config dict received from Antenna task (may be None)
+        pipeline_config: Pipeline config received from Antenna task (may be None)
 
     Returns:
         (n_items, n_detections, batch_results, detect_time, classify_time)
@@ -354,7 +354,7 @@ def _process_batch(
                 source_images=[source_image],
                 detections=image_detections[image_id],
                 total_time=batch_elapsed / len(image_ids),
-                config=PipelineConfigRequest(**(pipeline_config or {})),
+                config=pipeline_config or PipelineConfigRequest(),
             )
             batch_results.append(
                 AntennaTaskResult(


### PR DESCRIPTION
## Summary

This is the ADC half of [RolnickLab/antenna#1279](https://github.com/RolnickLab/antenna/pull/1279). Antenna now embeds pipeline config in each NATS task; this PR teaches the ADC worker to receive that config, thread it through the dataset/collate/process layers, and echo it back on the result so Antenna can log what config was actually used.

It is **structural only** — no config values are read or applied during inference yet. The new `config` field flows end-to-end but the worker's behavior is unchanged. Real config parameters and their use in inference are follow-ups.

Config is typed as `PipelineConfigRequest` (not generic `dict`) on receive, so pydantic parses and validates the shape at the boundary. Adding a new config parameter means adding a field to `PipelineConfigRequest` in `trapdata/api/schemas.py`; unknown keys are dropped silently — see RolnickLab/antenna#1279 for the Antenna-side audit log that flags drift.

- `AntennaPipelineProcessingTask.config: PipelineConfigRequest | None` receives the pipeline config embedded by Antenna in each NATS task
- `datasets.py` iterator yields `config` per row; `rest_collate_fn` passes the first task's config through the batch dict (all tasks in a job share the same config)
- `_process_batch` receives `pipeline_config: PipelineConfigRequest | None` and passes it to `PipelineResultsResponse.config` so Antenna can log which config was actually used
- Fallback: `config=None` → `PipelineConfigRequest()` defaults apply; existing workers unaffected

## Test plan

- [ ] E2E: set a `ProjectPipelineConfig` in Antenna, start an async job, confirm `PipelineResultsResponse.config` in the result matches the project config and that no drift warning is logged on the Antenna side
- [ ] Mismatch case: edit `ProjectPipelineConfig` mid-job and confirm Antenna logs the drift warning
- [ ] Default behavior unchanged when Antenna sends no config (None)

## Companion PR

RolnickLab/antenna#1279 — Antenna side: embed config in NATS tasks, plus audit log for drift

Related: RolnickLab/antenna#1275