### PR TITLE
Split oversized result uploads so wide-taxonomy batches don't get rejected

### DIFF
--- a/trapdata/antenna/benchmark.py
+++ b/trapdata/antenna/benchmark.py
@@ -87,8 +87,13 @@ def run_benchmark(
         settings=settings,
     )
 
-    # Initialize ResultPoster for sending acknowledgments
-    result_poster = ResultPoster(max_pending=10)
+    # Initialize ResultPoster for sending acknowledgments. It takes the same
+    # per-POST size cap as the worker so a benchmark measures the number of
+    # requests a tuned deployment would actually make.
+    result_poster = ResultPoster(
+        max_pending=10,
+        max_post_bytes=settings.antenna_result_post_max_bytes,
+    )
 
     # Performance metrics
     total_batches = 0

--- a/trapdata/antenna/client.py
+++ b/trapdata/antenna/client.py
@@ -1,5 +1,6 @@
 """Antenna API client for fetching jobs and posting results."""
 
+import json
 import socket
 
 import requests
@@ -13,6 +14,12 @@ from trapdata.antenna.schemas import (
 )
 from trapdata.api.utils import get_http_session
 from trapdata.common.logs import logger
+
+# Default maximum size (bytes) of a single result POST body. Used when a caller
+# does not pass an explicit limit (e.g. settings.antenna_result_post_max_bytes).
+# Chosen to stay well under the reverse-proxy request-body limit (commonly 100 MB)
+# while still allowing several wide-taxonomy detections per request.
+DEFAULT_RESULT_POST_MAX_BYTES = 25 * 1024 * 1024
 
 
 def get_full_service_name(service_name: str) -> str:
@@ -71,41 +78,133 @@ def get_jobs(
             return []
 
 
+def _result_json_size(result_json: dict) -> int:
+    """Approximate the serialized byte size of one result entry.
+
+    Uses a compact JSON encoding (no extra whitespace) so the estimate tracks
+    what ``requests`` actually sends. The few bytes of array/comma framing that
+    join entries in the final payload are ignored; they are negligible next to
+    the per-result content for wide-taxonomy classifiers.
+    """
+    return len(json.dumps(result_json, separators=(",", ":")).encode("utf-8"))
+
+
+def chunk_results_by_size(
+    results_json: list[dict],
+    max_bytes: int,
+) -> list[list[dict]]:
+    """Greedily pack already-serialized result dicts into byte-bounded chunks.
+
+    Each returned chunk, once wrapped in the ``{"results": [...]}`` envelope, is
+    intended to stay at or below ``max_bytes``. A single result that exceeds
+    ``max_bytes`` on its own is emitted as its own chunk (it cannot be split
+    further without changing the per-image API contract), and a warning is
+    logged so the oversize case is visible.
+
+    Args:
+        results_json: Result entries already converted to JSON-compatible dicts.
+        max_bytes: Target maximum size in bytes for one POST body.
+
+    Returns:
+        A list of chunks, where each chunk is a list of result dicts. Returns an
+        empty list when given no results.
+    """
+    if not results_json:
+        return []
+    if max_bytes <= 0:
+        # Defensive: a non-positive cap would otherwise loop forever. Fall back
+        # to posting everything in a single chunk.
+        return [list(results_json)]
+
+    # Account for the constant envelope overhead of ``{"results":[]}``.
+    envelope_overhead = len(b'{"results":[]}')
+    budget = max(1, max_bytes - envelope_overhead)
+
+    chunks: list[list[dict]] = []
+    current: list[dict] = []
+    current_size = 0
+
+    for result_json in results_json:
+        size = _result_json_size(result_json)
+        if size > budget:
+            logger.warning(
+                f"Single result entry is {size} bytes, larger than the "
+                f"{max_bytes}-byte POST limit; sending it in its own request. "
+                "It may still be rejected by the server or proxy."
+            )
+        # +1 accounts for the comma joining this entry to the previous one.
+        added_size = size + (1 if current else 0)
+        if current and current_size + added_size > budget:
+            chunks.append(current)
+            current = []
+            current_size = 0
+            added_size = size
+        current.append(result_json)
+        current_size += added_size
+
+    if current:
+        chunks.append(current)
+    return chunks
+
+
 def post_batch_results(
     base_url: str,
     auth_token: str,
     job_id: int,
     results: list[AntennaTaskResult],
+    max_bytes: int = DEFAULT_RESULT_POST_MAX_BYTES,
 ) -> bool:
     """
-    Post batch results back to the API.
+    Post batch results back to the API, splitting large batches across requests.
+
+    The results for one processed batch are serialized once and packed into one
+    or more POST bodies that each stay at or below ``max_bytes``. This prevents a
+    single dense, wide-taxonomy batch from producing a request body large enough
+    to be rejected by the reverse proxy (HTTP 413).
 
     Args:
         base_url: Antenna API base URL (e.g., "http://localhost:8000/api/v2")
         auth_token: API authentication token
         job_id: Job ID
         results: List of AntennaTaskResult objects
+        max_bytes: Maximum size in bytes of a single POST body.
 
     Returns:
-        True if successful, False otherwise
+        True only if every chunk was posted successfully, False otherwise.
     """
-    url = f"{base_url.rstrip('/')}/jobs/{job_id}/result/"
-    payload = AntennaTaskResults(results=results)
+    if not results:
+        return True
 
+    url = f"{base_url.rstrip('/')}/jobs/{job_id}/result/"
+
+    # Serialize each result once, then group into byte-bounded chunks so we never
+    # pay the serialization cost twice.
+    results_json = [
+        AntennaTaskResults(results=[r]).model_dump(mode="json")["results"][0]
+        for r in results
+    ]
+    chunks = chunk_results_by_size(results_json, max_bytes)
+
+    all_ok = True
     with get_http_session(auth_token) as session:
-        try:
-            response = session.post(
-                url, json=payload.model_dump(mode="json"), timeout=60
-            )
-            response.raise_for_status()
-            result = AntennaResultPostResponse.model_validate(response.json())
-            logger.debug(
-                f"Posted {len(results)} results to job {job_id}: {result.results_queued} queued"
-            )
-            return True
-        except requests.RequestException as e:
-            logger.error(f"Failed to post results to {url}: {e}")
-            return False
+        for chunk_idx, chunk in enumerate(chunks):
+            payload = {"results": chunk}
+            try:
+                response = session.post(url, json=payload, timeout=60)
+                response.raise_for_status()
+                result = AntennaResultPostResponse.model_validate(response.json())
+                logger.debug(
+                    f"Posted chunk {chunk_idx + 1}/{len(chunks)} "
+                    f"({len(chunk)} results) to job {job_id}: "
+                    f"{result.results_queued} queued"
+                )
+            except requests.RequestException as e:
+                logger.error(
+                    f"Failed to post result chunk {chunk_idx + 1}/{len(chunks)} "
+                    f"to {url}: {e}"
+                )
+                all_ok = False
+    return all_ok
 
 
 def get_user_projects(base_url: str, auth_token: str) -> list[dict]:

--- a/trapdata/antenna/client.py
+++ b/trapdata/antenna/client.py
@@ -78,15 +78,32 @@ def get_jobs(
             return []
 
 
-def _result_json_size(result_json: dict) -> int:
-    """Approximate the serialized byte size of one result entry.
+def _encoded_size(obj) -> int:
+    """Measure the bytes ``obj`` occupies once sent as a JSON request body.
 
-    Uses a compact JSON encoding (no extra whitespace) so the estimate tracks
-    what ``requests`` actually sends. The few bytes of array/comma framing that
-    join entries in the final payload are ignored; they are negligible next to
-    the per-result content for wide-taxonomy classifiers.
+    ``requests`` serializes a ``json=`` argument with ``json.dumps`` defaults,
+    which put a space after every comma and colon. Across the long numeric
+    ``scores`` and ``logits`` arrays a wide-taxonomy classifier emits, that
+    whitespace is roughly a quarter of the body, so measuring a compact encoding
+    instead would let a chunk packed just under the cap go out well over it.
     """
-    return len(json.dumps(result_json, separators=(",", ":")).encode("utf-8"))
+    return len(json.dumps(obj, allow_nan=False).encode("utf-8"))
+
+
+# Fixed costs of the ``{"results": [...]}`` envelope and of the ``, `` the
+# encoder puts between entries. Derived from the encoder rather than written out
+# so they stay correct if its settings ever change.
+_ENVELOPE_BYTES = _encoded_size({"results": []})
+_ENTRY_SEPARATOR_BYTES = _encoded_size([0, 0]) - 2 * _encoded_size(0) - len("[]")
+
+
+def _result_json_size(result_json: dict) -> int:
+    """Measure one result entry as encoded inside a request body.
+
+    Excludes the surrounding envelope and the separator joining entries; the
+    packer accounts for those itself.
+    """
+    return _encoded_size(result_json)
 
 
 def chunk_results_by_size(
@@ -116,9 +133,7 @@ def chunk_results_by_size(
         # to posting everything in a single chunk.
         return [list(results_json)]
 
-    # Account for the constant envelope overhead of ``{"results":[]}``.
-    envelope_overhead = len(b'{"results":[]}')
-    budget = max(1, max_bytes - envelope_overhead)
+    budget = max(1, max_bytes - _ENVELOPE_BYTES)
 
     chunks: list[list[dict]] = []
     current: list[dict] = []
@@ -132,8 +147,7 @@ def chunk_results_by_size(
                 f"{max_bytes}-byte POST limit; sending it in its own request. "
                 "It may still be rejected by the server or proxy."
             )
-        # +1 accounts for the comma joining this entry to the previous one.
-        added_size = size + (1 if current else 0)
+        added_size = size + (_ENTRY_SEPARATOR_BYTES if current else 0)
         if current and current_size + added_size > budget:
             chunks.append(current)
             current = []
@@ -162,6 +176,14 @@ def post_batch_results(
     single dense, wide-taxonomy batch from producing a request body large enough
     to be rejected by the reverse proxy (HTTP 413).
 
+    Splitting is safe because the server treats a POST body as a container of
+    independent results: it queues and acknowledges each one by its own
+    ``reply_subject``. A chunk that fails to post therefore leaves only its own
+    images unacknowledged, to be redelivered later, while results from chunks
+    that did land stay recorded. For that reason a failed chunk does not abort
+    the ones after it: posting them acknowledges work that is already done,
+    rather than forcing it to be repeated.
+
     Args:
         base_url: Antenna API base URL (e.g., "http://localhost:8000/api/v2")
         auth_token: API authentication token
@@ -170,7 +192,8 @@ def post_batch_results(
         max_bytes: Maximum size in bytes of a single POST body.
 
     Returns:
-        True only if every chunk was posted successfully, False otherwise.
+        True only if every chunk was posted successfully, False otherwise. A
+        partial failure returns False even though some results were recorded.
     """
     if not results:
         return True
@@ -188,9 +211,8 @@ def post_batch_results(
     all_ok = True
     with get_http_session(auth_token) as session:
         for chunk_idx, chunk in enumerate(chunks):
-            payload = {"results": chunk}
             try:
-                response = session.post(url, json=payload, timeout=60)
+                response = session.post(url, json={"results": chunk}, timeout=60)
                 response.raise_for_status()
                 result = AntennaResultPostResponse.model_validate(response.json())
                 logger.debug(
@@ -198,7 +220,12 @@ def post_batch_results(
                     f"({len(chunk)} results) to job {job_id}: "
                     f"{result.results_queued} queued"
                 )
-            except requests.RequestException as e:
+            # ValueError covers a malformed or off-schema response body as well
+            # as a non-finite score: ``requests``' JSONDecodeError and Pydantic's
+            # ValidationError are both ValueError subclasses. Catching them per
+            # chunk keeps one bad response from stranding the chunks behind it,
+            # which would leave their images to be redelivered for no reason.
+            except (requests.RequestException, ValueError) as e:
                 logger.error(
                     f"Failed to post result chunk {chunk_idx + 1}/{len(chunks)} "
                     f"to {url}: {e}"

--- a/trapdata/antenna/result_posting.py
+++ b/trapdata/antenna/result_posting.py
@@ -24,7 +24,7 @@ import time
 from concurrent.futures import FIRST_COMPLETED, Future, ThreadPoolExecutor, wait
 from dataclasses import dataclass
 
-from trapdata.antenna.client import post_batch_results
+from trapdata.antenna.client import DEFAULT_RESULT_POST_MAX_BYTES, post_batch_results
 from trapdata.common.logs import logger
 
 
@@ -69,9 +69,11 @@ class ResultPoster:
         self,
         max_pending: int = 5,
         future_timeout: float = 30.0,
+        max_post_bytes: int = DEFAULT_RESULT_POST_MAX_BYTES,
     ):
         self.max_pending = max_pending
         self.future_timeout = future_timeout  # Timeout for individual future waits
+        self.max_post_bytes = max_post_bytes  # Per-POST body size cap (bytes)
         self.executor = ThreadPoolExecutor(
             max_workers=2, thread_name_prefix="result_poster"
         )
@@ -167,7 +169,13 @@ class ResultPoster:
             True if successful, False otherwise
         """
         try:
-            success = post_batch_results(base_url, auth_token, job_id, results)
+            success = post_batch_results(
+                base_url,
+                auth_token,
+                job_id,
+                results,
+                max_bytes=self.max_post_bytes,
+            )
             elapsed_time = time.time() - start_time
 
             with self._metrics_lock:

--- a/trapdata/antenna/result_posting.py
+++ b/trapdata/antenna/result_posting.py
@@ -57,6 +57,9 @@ class ResultPoster:
 
     Args:
         max_pending: Maximum number of concurrent posts before blocking (default: 5)
+        future_timeout: Seconds to wait on any single pending post (default: 30)
+        max_post_bytes: Maximum size in bytes of one POST body (default: 25 MiB).
+            A batch whose results exceed this is split across several POSTs.
 
     Example:
         poster = ResultPoster(max_pending=10)

--- a/trapdata/antenna/tests/test_result_chunking.py
+++ b/trapdata/antenna/tests/test_result_chunking.py
@@ -1,0 +1,195 @@
+"""Tests for byte-bounded chunking of result POSTs to the Antenna API.
+
+These tests reproduce the production failure mode where a single result POST for
+a wide-taxonomy pipeline (e.g. the global moths model, ~29k classes) grew to
+100+ MB and was rejected by the reverse proxy with HTTP 413. The fix splits the
+results for one processed batch across multiple POSTs so each request body stays
+under a configurable size cap.
+"""
+
+import datetime
+import json
+from unittest import TestCase
+from unittest.mock import MagicMock, patch
+
+from trapdata.antenna.client import chunk_results_by_size, post_batch_results
+from trapdata.antenna.schemas import AntennaTaskResult, AntennaTaskResults
+from trapdata.api.schemas import (
+    AlgorithmReference,
+    BoundingBox,
+    ClassificationResponse,
+    DetectionResponse,
+    PipelineResultsResponse,
+    SourceImageResponse,
+)
+
+
+def _make_detection(image_id: str, num_classes: int) -> DetectionResponse:
+    """Build a DetectionResponse carrying full-width classification arrays.
+
+    This mirrors what the global moths classifier emits: one classification with
+    labels/scores/logits arrays each of length ``num_classes``.
+    """
+    labels = [f"Genus_species_{i:06d}" for i in range(num_classes)]
+    scores = [1.0 / num_classes] * num_classes
+    logits = [float(i) for i in range(num_classes)]
+    return DetectionResponse(
+        source_image_id=image_id,
+        bbox=BoundingBox(x1=0, y1=0, x2=100, y2=100),
+        algorithm=AlgorithmReference(name="Object Detector", key="detector"),
+        timestamp=datetime.datetime(2024, 1, 1, 0, 0, 0),
+        classifications=[
+            ClassificationResponse(
+                classification=labels[0],
+                labels=labels,
+                scores=scores,
+                logits=logits,
+                algorithm=AlgorithmReference(
+                    name="Global Species Classifier", key="global_moths_2024"
+                ),
+                timestamp=datetime.datetime(2024, 1, 1, 0, 0, 0),
+            )
+        ],
+    )
+
+
+def _make_result(
+    image_id: str, num_classes: int, detections_per_image: int = 1
+) -> AntennaTaskResult:
+    """Build one AntennaTaskResult for a single image with N wide detections."""
+    detections = [
+        _make_detection(image_id, num_classes) for _ in range(detections_per_image)
+    ]
+    return AntennaTaskResult(
+        reply_subject=f"reply.{image_id}",
+        result=PipelineResultsResponse(
+            pipeline="global_moths_2024",
+            source_images=[
+                SourceImageResponse(id=image_id, url=f"http://x/{image_id}")
+            ],
+            detections=detections,
+            total_time=1.0,
+        ),
+    )
+
+
+def _serialized_body_size(results: list[AntennaTaskResult]) -> int:
+    """Size in bytes of the JSON body actually sent for a list of results."""
+    payload = AntennaTaskResults(results=results).model_dump(mode="json")
+    return len(json.dumps(payload).encode("utf-8"))
+
+
+class TestChunkResultsBySize(TestCase):
+    """Unit tests for the greedy byte-bounded packer."""
+
+    def test_empty_results_yields_no_chunks(self):
+        self.assertEqual(chunk_results_by_size([], max_bytes=1000), [])
+
+    def test_each_chunk_stays_under_cap(self):
+        # ~29k-class detections: each result is ~2 MB. A cap of 5 MB should pack
+        # at most ~2 results per chunk.
+        num_classes = 29_000
+        results = [_make_result(f"img{i}", num_classes) for i in range(8)]
+        results_json = AntennaTaskResults(results=results).model_dump(mode="json")[
+            "results"
+        ]
+
+        max_bytes = 5 * 1024 * 1024
+        chunks = chunk_results_by_size(results_json, max_bytes=max_bytes)
+
+        self.assertGreater(len(chunks), 1, "expected the batch to be split")
+        for chunk in chunks:
+            body_size = len(json.dumps({"results": chunk}).encode("utf-8"))
+            self.assertLessEqual(
+                body_size,
+                max_bytes,
+                f"chunk body {body_size} exceeded cap {max_bytes}",
+            )
+
+    def test_no_results_dropped(self):
+        num_classes = 1_000
+        results = [_make_result(f"img{i}", num_classes) for i in range(10)]
+        results_json = AntennaTaskResults(results=results).model_dump(mode="json")[
+            "results"
+        ]
+        chunks = chunk_results_by_size(results_json, max_bytes=500_000)
+        total = sum(len(c) for c in chunks)
+        self.assertEqual(total, len(results))
+
+    def test_oversize_single_result_gets_own_chunk(self):
+        # One result larger than the cap cannot be split below one image; it must
+        # still be emitted (in its own chunk) rather than dropped.
+        num_classes = 29_000
+        results = [_make_result("big", num_classes, detections_per_image=4)]
+        results_json = AntennaTaskResults(results=results).model_dump(mode="json")[
+            "results"
+        ]
+        chunks = chunk_results_by_size(results_json, max_bytes=1 * 1024 * 1024)
+        self.assertEqual(len(chunks), 1)
+        self.assertEqual(len(chunks[0]), 1)
+
+
+class TestPostBatchResultsChunking(TestCase):
+    """post_batch_results must split a large batch across multiple POST bodies."""
+
+    def test_large_batch_split_into_multiple_under_cap_posts(self):
+        num_classes = 29_000
+        # 8 images, each a single wide detection (~2 MB) -> ~15 MB total.
+        results = [_make_result(f"img{i}", num_classes) for i in range(8)]
+
+        max_bytes = 4 * 1024 * 1024
+        posted_bodies: list[int] = []
+
+        fake_response = MagicMock()
+        fake_response.raise_for_status.return_value = None
+        fake_response.json.return_value = {
+            "status": "accepted",
+            "job_id": 1,
+            "results_queued": 0,
+        }
+
+        def fake_post(url, json=None, timeout=None):
+            body_size = len(__import__("json").dumps(json).encode("utf-8"))
+            posted_bodies.append(body_size)
+            return fake_response
+
+        fake_session = MagicMock()
+        fake_session.post.side_effect = fake_post
+        fake_session.__enter__.return_value = fake_session
+        fake_session.__exit__.return_value = False
+
+        with patch(
+            "trapdata.antenna.client.get_http_session", return_value=fake_session
+        ):
+            ok = post_batch_results(
+                base_url="http://x/api/v2",
+                auth_token="t",
+                job_id=1,
+                results=results,
+                max_bytes=max_bytes,
+            )
+
+        self.assertTrue(ok)
+        self.assertGreater(len(posted_bodies), 1, "expected multiple POSTs")
+        for size in posted_bodies:
+            self.assertLessEqual(size, max_bytes, f"POST body {size} exceeded cap")
+
+    def test_unsplit_baseline_would_exceed_cap(self):
+        # Sanity check that the un-chunked body really is over the cap, so the
+        # test above is exercising a real split, not a no-op.
+        num_classes = 29_000
+        results = [_make_result(f"img{i}", num_classes) for i in range(8)]
+        body_size = _serialized_body_size(results)
+        self.assertGreater(body_size, 4 * 1024 * 1024)
+
+    def test_empty_results_is_noop_success(self):
+        with patch("trapdata.antenna.client.get_http_session") as get_session:
+            ok = post_batch_results(
+                base_url="http://x/api/v2",
+                auth_token="t",
+                job_id=1,
+                results=[],
+                max_bytes=1000,
+            )
+        self.assertTrue(ok)
+        get_session.assert_not_called()

--- a/trapdata/antenna/tests/test_result_chunking.py
+++ b/trapdata/antenna/tests/test_result_chunking.py
@@ -12,6 +12,8 @@ import json
 from unittest import TestCase
 from unittest.mock import MagicMock, patch
 
+import requests
+
 from trapdata.antenna.client import chunk_results_by_size, post_batch_results
 from trapdata.antenna.schemas import AntennaTaskResult, AntennaTaskResults
 from trapdata.api.schemas import (
@@ -73,10 +75,21 @@ def _make_result(
     )
 
 
+def _encoded_body_size(payload) -> int:
+    """Size of the request body ``requests`` would build from ``payload``.
+
+    Mirrors requests' own encoding, which uses ``json.dumps`` defaults and so
+    puts a space after every comma and colon. Measuring a compact encoding here
+    would understate the wire size by roughly a quarter on these array-heavy
+    payloads and let an over-cap body pass the assertions below.
+    """
+    return len(json.dumps(payload).encode("utf-8"))
+
+
 def _serialized_body_size(results: list[AntennaTaskResult]) -> int:
     """Size in bytes of the JSON body actually sent for a list of results."""
     payload = AntennaTaskResults(results=results).model_dump(mode="json")
-    return len(json.dumps(payload).encode("utf-8"))
+    return _encoded_body_size(payload)
 
 
 class TestChunkResultsBySize(TestCase):
@@ -99,7 +112,7 @@ class TestChunkResultsBySize(TestCase):
 
         self.assertGreater(len(chunks), 1, "expected the batch to be split")
         for chunk in chunks:
-            body_size = len(json.dumps({"results": chunk}).encode("utf-8"))
+            body_size = _encoded_body_size({"results": chunk})
             self.assertLessEqual(
                 body_size,
                 max_bytes,
@@ -149,8 +162,7 @@ class TestPostBatchResultsChunking(TestCase):
         }
 
         def fake_post(url, json=None, timeout=None):
-            body_size = len(__import__("json").dumps(json).encode("utf-8"))
-            posted_bodies.append(body_size)
+            posted_bodies.append(_encoded_body_size(json))
             return fake_response
 
         fake_session = MagicMock()
@@ -193,3 +205,195 @@ class TestPostBatchResultsChunking(TestCase):
             )
         self.assertTrue(ok)
         get_session.assert_not_called()
+
+    def test_posted_bodies_stay_under_cap_at_requests_encoding(self):
+        """The cap must bound the bytes sent, measured as ``requests`` encodes them.
+
+        The packer sizes entries the same way requests serializes them, spaces
+        after separators included. Were it to measure a compact encoding instead,
+        these array-heavy bodies would go out roughly a quarter over the cap and
+        draw the HTTP 413 the chunking exists to avoid.
+        """
+        num_classes = 29_000
+        results = [_make_result(f"img{i}", num_classes) for i in range(8)]
+        max_bytes = 4 * 1024 * 1024
+        sent_sizes: list[int] = []
+
+        fake_response = MagicMock()
+        fake_response.raise_for_status.return_value = None
+        fake_response.json.return_value = {
+            "status": "accepted",
+            "job_id": 1,
+            "results_queued": 0,
+        }
+
+        def fake_post(url, json=None, timeout=None):
+            sent_sizes.append(_encoded_body_size(json))
+            return fake_response
+
+        fake_session = MagicMock()
+        fake_session.post.side_effect = fake_post
+        fake_session.__enter__.return_value = fake_session
+        fake_session.__exit__.return_value = False
+
+        with patch(
+            "trapdata.antenna.client.get_http_session", return_value=fake_session
+        ):
+            ok = post_batch_results(
+                base_url="http://x/api/v2",
+                auth_token="t",
+                job_id=1,
+                results=results,
+                max_bytes=max_bytes,
+            )
+
+        self.assertTrue(ok)
+        self.assertGreater(len(sent_sizes), 1, "expected multiple POSTs")
+        for size in sent_sizes:
+            self.assertLessEqual(size, max_bytes, f"sent body {size} exceeded cap")
+
+
+class TestPostBatchResultsFailureSemantics(TestCase):
+    """How a failing chunk affects the other chunks and the return value.
+
+    The server queues and acknowledges each result by its own ``reply_subject``,
+    so a chunk that fails leaves only its own images unacknowledged for
+    redelivery. Chunks after it must still be attempted -- skipping them would
+    discard work that is already done -- while the caller must still be told the
+    batch was not fully recorded.
+    """
+
+    def _run_with_chunk_outcomes(self, outcomes: list[Exception | None]):
+        """Post 8 wide results, failing the Nth POST per ``outcomes``.
+
+        Returns (return_value, number_of_POSTs_attempted).
+        """
+        results = [_make_result(f"img{i}", 29_000) for i in range(8)]
+        attempts = {"n": 0}
+
+        ok_response = MagicMock()
+        ok_response.raise_for_status.return_value = None
+        ok_response.json.return_value = {
+            "status": "accepted",
+            "job_id": 1,
+            "results_queued": 0,
+        }
+
+        def fake_post(url, json=None, timeout=None):
+            idx = attempts["n"]
+            attempts["n"] += 1
+            outcome = outcomes[idx] if idx < len(outcomes) else None
+            if outcome is not None:
+                raise outcome
+            return ok_response
+
+        fake_session = MagicMock()
+        fake_session.post.side_effect = fake_post
+        fake_session.__enter__.return_value = fake_session
+        fake_session.__exit__.return_value = False
+
+        with patch(
+            "trapdata.antenna.client.get_http_session", return_value=fake_session
+        ):
+            ok = post_batch_results(
+                base_url="http://x/api/v2",
+                auth_token="t",
+                job_id=1,
+                results=results,
+                # 4 MB against ~2 MB results forces several chunks.
+                max_bytes=4 * 1024 * 1024,
+            )
+        return ok, attempts["n"]
+
+    def test_one_failed_chunk_reports_failure(self):
+        ok, _ = self._run_with_chunk_outcomes([requests.RequestException("boom")])
+        self.assertFalse(ok, "a partially posted batch must not report success")
+
+    def test_remaining_chunks_are_still_posted_after_a_failure(self):
+        _, attempted = self._run_with_chunk_outcomes(
+            [requests.RequestException("boom")]
+        )
+        _, total_chunks = self._run_with_chunk_outcomes([])
+        self.assertEqual(
+            attempted,
+            total_chunks,
+            "a failed chunk must not strand the chunks behind it",
+        )
+
+    def test_all_chunks_succeeding_reports_success(self):
+        ok, attempted = self._run_with_chunk_outcomes([])
+        self.assertTrue(ok)
+        self.assertGreater(attempted, 1, "expected the batch to be split")
+
+    def test_offschema_response_is_caught_per_chunk(self):
+        """A response that parses but does not match the schema fails one chunk.
+
+        ``model_validate`` raises Pydantic's ValidationError, which is not a
+        ``requests`` exception. Left uncaught it would escape the loop and strand
+        every chunk behind it.
+        """
+        bad_response = MagicMock()
+        bad_response.raise_for_status.return_value = None
+        bad_response.json.return_value = {"unexpected": "shape"}
+
+        results = [_make_result(f"img{i}", 29_000) for i in range(8)]
+        attempts = {"n": 0}
+
+        def fake_post(url, json=None, timeout=None):
+            attempts["n"] += 1
+            return bad_response
+
+        fake_session = MagicMock()
+        fake_session.post.side_effect = fake_post
+        fake_session.__enter__.return_value = fake_session
+        fake_session.__exit__.return_value = False
+
+        with patch(
+            "trapdata.antenna.client.get_http_session", return_value=fake_session
+        ):
+            ok = post_batch_results(
+                base_url="http://x/api/v2",
+                auth_token="t",
+                job_id=1,
+                results=results,
+                max_bytes=4 * 1024 * 1024,
+            )
+
+        self.assertFalse(ok)
+        self.assertGreater(
+            attempts["n"], 1, "validation failure must not abort later chunks"
+        )
+
+    def test_undecodable_response_is_caught_per_chunk(self):
+        """A non-JSON response body fails one chunk rather than the loop."""
+        bad_response = MagicMock()
+        bad_response.raise_for_status.return_value = None
+        bad_response.json.side_effect = requests.exceptions.JSONDecodeError(
+            "no json", "", 0
+        )
+
+        results = [_make_result(f"img{i}", 29_000) for i in range(8)]
+        attempts = {"n": 0}
+
+        def fake_post(url, json=None, timeout=None):
+            attempts["n"] += 1
+            return bad_response
+
+        fake_session = MagicMock()
+        fake_session.post.side_effect = fake_post
+        fake_session.__enter__.return_value = fake_session
+        fake_session.__exit__.return_value = False
+
+        with patch(
+            "trapdata.antenna.client.get_http_session", return_value=fake_session
+        ):
+            ok = post_batch_results(
+                base_url="http://x/api/v2",
+                auth_token="t",
+                job_id=1,
+                results=results,
+                max_bytes=4 * 1024 * 1024,
+            )
+
+        self.assertFalse(ok)
+        self.assertGreater(attempts["n"], 1)

--- a/trapdata/antenna/tests/test_worker.py
+++ b/trapdata/antenna/tests/test_worker.py
@@ -259,7 +259,12 @@ class TestProcessJobIntegration(TestCase):
         settings.antenna_api_auth_token = "test-token"
         settings.antenna_api_batch_size = 2
         settings.num_workers = 0  # Disable multiprocessing for tests
-        settings.localization_batch_size = 2  # Real integer for batch processing
+        # Numeric settings need real numbers. A bare MagicMock attribute returns
+        # another MagicMock, which raises TypeError once the worker compares it
+        # against an int -- far from here, and surfacing only as results that
+        # never got posted.
+        settings.localization_batch_size = 2
+        settings.antenna_result_post_max_bytes = 25 * 1024 * 1024
         return settings
 
     def test_empty_queue(self):
@@ -420,7 +425,10 @@ class TestWorkerEndToEnd(TestCase):
         settings.antenna_api_auth_token = "test-token"
         settings.antenna_api_batch_size = 2
         settings.num_workers = 0
-        settings.localization_batch_size = 2  # Real integer for batch processing
+        # See the note on the matching helper above: numeric settings need real
+        # numbers or the worker fails deep in the call with a TypeError.
+        settings.localization_batch_size = 2
+        settings.antenna_result_post_max_bytes = 25 * 1024 * 1024
         return settings
 
     def test_full_workflow_with_real_inference(self):

--- a/trapdata/antenna/worker.py
+++ b/trapdata/antenna/worker.py
@@ -465,7 +465,10 @@ def _process_job(
             if not classifier:
                 classifier = classifier_class(source_images=[], detections=[])
                 detector = APIMothDetector([])
-                result_poster = ResultPoster(max_pending=MAX_PENDING_POSTS)
+                result_poster = ResultPoster(
+                    max_pending=MAX_PENDING_POSTS,
+                    max_post_bytes=settings.antenna_result_post_max_bytes,
+                )
 
                 if use_binary_filter:
                     binary_filter = MothClassifierBinary(

--- a/trapdata/settings.py
+++ b/trapdata/settings.py
@@ -42,6 +42,14 @@ class Settings(BaseSettings):
     antenna_api_auth_token: str = ""
     antenna_service_name: str = "AMI Data Companion"
     antenna_api_batch_size: int = 24
+    # Maximum size (in bytes) of a single result POST body to the Antenna API.
+    # The results for one processed batch are split across multiple POSTs so that
+    # no single request exceeds this limit. Wide-taxonomy classifiers (e.g. the
+    # global moths model with ~29k classes) emit ~2 MB per detection because each
+    # classification carries full-length labels/scores/logits arrays, so a dense
+    # batch can otherwise produce a 100+ MB body that reverse proxies reject (413).
+    # Default 25 MB leaves headroom under common proxy limits (typically 100 MB).
+    antenna_result_post_max_bytes: int = 25 * 1024 * 1024
 
     @pydantic.field_validator("image_base_path", "user_data_path")
     def validate_path(cls, v):
@@ -167,6 +175,15 @@ class Settings(BaseSettings):
             "antenna_api_batch_size": {
                 "title": "Antenna API Batch Size",
                 "description": "Number of tasks to fetch from Antenna per batch",
+                "kivy_type": "numeric",
+                "kivy_section": "antenna",
+            },
+            "antenna_result_post_max_bytes": {
+                "title": "Antenna Result POST Max Bytes",
+                "description": (
+                    "Maximum size in bytes of a single result POST body; results "
+                    "for a batch are split across multiple POSTs to stay under it"
+                ),
                 "kivy_type": "numeric",
                 "kivy_section": "antenna",
             },


### PR DESCRIPTION
## Summary

For models with very large taxonomies — for example the ~29,000-class `global_moths_2024` classifier — a single batch's result upload can reach 110–142 MB, because every detection carries full per-class `scores` and `logits` arrays. In a production deployment those uploads were rejected by the reverse proxy with HTTP 413 (Request Entity Too Large), so the worker could never record its results: the upload failed, the task was never acknowledged, it eventually exhausted its redelivery budget, and the job failed with nothing stored. Smaller-taxonomy jobs were unaffected, which is why this stayed invisible until a wide-taxonomy job ran on a dense capture set.

This change makes the worker split a batch's results across multiple smaller uploads, each kept under a configurable byte cap, so wide-taxonomy jobs complete regardless of the proxy's request-body limit. It is a client-side fix that needs no server change.

Splitting is safe because of how the API already works: a request body is a container of independent results, and the server queues and acknowledges each one by its own `reply_subject`. Which upload carried a given result makes no difference to how it is processed. If one upload fails, only the images it carried go unacknowledged and are redelivered later; results from uploads that succeeded stay recorded, and are not sent twice.

### List of Changes

| # | Change (user/operator effect) | How (implementation) |
|---|---|---|
| 1 | Result uploads for large-taxonomy models now succeed instead of being rejected for size. | New `chunk_results_by_size()` greedy byte-bounded packer in `client.py`; `post_batch_results()` serializes each result once, packs results into uploads under `max_bytes`, and posts each one. A single result that exceeds the cap on its own is sent alone and logged. |
| 2 | The size cap now bounds the bytes actually sent, rather than an undercount of them. | Sizes were measured with a compact JSON encoding, but `requests` serializes with `json.dumps` defaults, which add a space after every comma and colon. On long numeric arrays that is about a quarter of the body, so the cap was advisory rather than enforced: at the 25 MB default, a batch from the ~29k-class model packed into a 25.06 MB request. Measurement now matches the encoder, and the envelope and separator costs are derived from it instead of written out. |
| 3 | A single bad response from the server no longer strands the uploads queued behind it. | The handler caught only `requests.RequestException`, so a `ValidationError` from `AntennaResultPostResponse.model_validate()` escaped and aborted the loop. It now also catches `ValueError`, which covers both that and a non-finite score failing to encode. |
| 4 | Operators can tune the per-upload size cap per deployment. | New setting `antenna_result_post_max_bytes` → env var `AMI_ANTENNA_RESULT_POST_MAX_BYTES` (default 25 MB), threaded through `ResultPoster` into the worker. The benchmark tool takes the same setting, so a benchmark reports the request count a tuned deployment would really make. |
| 5 | Regression coverage for the splitting behaviour and its failure semantics. | `trapdata/antenna/tests/test_result_chunking.py` — 13 tests: packing under the cap, splitting a large batch, over-cap single results, upload sizes measured as `requests` encodes them, and the failure semantics described below. |

### Failure semantics

Worth stating explicitly, because the two halves sound contradictory and are not:

- **A failed upload does not stop the ones after it.** Each upload carries a different set of `reply_subject`s, so continuing acknowledges work that is already finished instead of forcing it to be redone.
- **`post_batch_results()` still returns `True` only if every upload succeeded.** A partial failure returns `False` even though some results were recorded.

Both are now pinned by tests (`TestPostBatchResultsFailureSemantics`). Note that the return value currently feeds metrics and logging only; recovery from a partial failure comes from redelivery of the unacknowledged images, not from the boolean.

### Diagnosis — why one batch reaches ~140 MB

- Each `ClassificationResponse` carries `scores` and `logits`, each an array of length = number of model classes. At ~29k classes that is ~1.1 MB per detection for those two arrays alone.
- The default batch is 24 images, and trap images routinely contain many moths each, so a batch of ~130 detections lands at roughly 120–140 MB — matching the observed rejected upload sizes.
- This is payload width, not duplication: the worker builds each upload from only the current batch's detections (`worker.py`), and the classifier/detector are reset per batch, so there is no cross-batch accumulation.

### Notes and follow-ups (out of scope for this PR)

Directions to discuss, ordered by leverage. Important context: result payloads are expected to **grow**, not shrink. `logits` are needed and will be kept, and per-crop vector embeddings are planned for each detection. That makes compressing the upload more valuable over time, and argues against tightening the proxy's body-size limit.

1. **Request gzip is the highest-leverage lever, and will matter more as payloads grow.** The worker posts raw JSON, and the API server compresses *responses* but has no request-body decompression (no `Content-Encoding: gzip` handling). The big arrays — `scores`, `logits`, and soon per-crop embeddings — are numeric and compress roughly 5–10×, so gzipping uploads could cut every request at the source. It requires the API server to accept and decompress gzipped request bodies first, and the reverse proxy to pass them through. Chunking was chosen here because it is client-side only and unblocks affected jobs now; gzip is the better long-term fix and the two compose rather than compete.
2. **Sending compact JSON would cut about 20% for free.** Encoding the body in the client and posting it as bytes, rather than handing `requests` a dict, removes the whitespace `json.dumps` adds by default. It was left out of this PR because the shared test HTTP shim forwards only the `json=` argument and would need updating alongside it.
3. **Keep generous size headroom.** Because `logits` stay and embeddings are coming, neither the per-upload cap nor the proxy body-size limit should be tightened. Chunking keeps individual uploads bounded regardless of how large a full batch's results become.
4. **`labels` is already omittable for large models.** The per-classification `labels` array is `list[str] | None` and documented as "omitted if the model has too many labels" on both the worker and server schemas, so for a 29k-class model it is most likely already dropped — a minor saving already realized. The bulk is `scores` + `logits` (and soon embeddings).

### Not yet verified

- No live-worker run. Chunking is verified by unit and integration tests against the serialization path, not against a real GPU job. This should be confirmed on a real large-taxonomy job, checking that each upload lands under the deployment's proxy limit.
- If a single image produces enough detections to exceed the cap on its own (~13+ dense detections at ~29k classes), that one result is still sent in a single upload — it cannot be split below one image without an API-contract change. The configurable cap plus a generous proxy limit covers this for now.

### Test status

`uv run python -m pytest trapdata/antenna/tests/ -q` → 26 passed. Full suite → 51 passed, 1 skipped, with `test_models.py::TestSourceImageSchema::test_url` failing on an external image host; that failure is unrelated to this branch and appears on others.