### PR TITLE
Make worker errors visible off-host by reporting them to Sentry

### DIFF
--- a/trapdata/antenna/worker.py
+++ b/trapdata/antenna/worker.py
@@ -7,6 +7,7 @@ import time
 from collections.abc import Callable
 
 import numpy as np
+import sentry_sdk
 import torch
 import torch.multiprocessing as mp
 
@@ -116,6 +117,10 @@ def _worker_loop(gpu_id: int, pipelines: list[str]):
                 )
                 any_jobs = any_jobs or any_work_done
             except Exception as e:
+                # Structlog does not route through the stdlib logging module, so
+                # Sentry's logging integration never sees these errors — capture
+                # explicitly to make worker failures visible off-host.
+                sentry_sdk.capture_exception(e)
                 logger.error(
                     f"[GPU {gpu_id}] Failed to process job {job_id} with pipeline {pipeline}: {e}",
                     exc_info=True,
@@ -359,6 +364,9 @@ def _process_batch(
                 )
             )
     except Exception as e:
+        # Captured explicitly for the same reason as the job-level handler:
+        # structlog errors are invisible to Sentry's logging integration.
+        sentry_sdk.capture_exception(e)
         logger.error(
             f"Batch {batch_num + 1} failed during processing: {e}", exc_info=True
         )


### PR DESCRIPTION
## Summary

When the Antenna worker fails to process a job, the error currently goes only to the log file on the worker machine itself. Nobody sees it unless they SSH in and read the log. In a recent production incident, a GPU licensing problem on a worker host caused every ML job to fail for several days before anyone noticed, because the failures were invisible from anywhere but the machine.

This change reports those errors to Sentry, where the team already monitors the other AMI services, so worker failures show up off-host within minutes instead of days.

### List of Changes

1. Errors that make a whole job attempt fail (for example a CUDA or model-loading problem) are now reported to Sentry — previously they were only written to the local log by the claim-loop handler.
2. Errors that make a single batch fail during processing are now also reported to Sentry — this handler already reports the error back to the Antenna API per task, and now the exception itself is captured too.

### Technical note

The worker logs through structlog, which does not route records through the stdlib `logging` module. Sentry's default logging integration only listens to stdlib logging, so `logger.error(...)` calls never reached Sentry even though `sentry_sdk.init()` runs at import time. The fix is an explicit `sentry_sdk.capture_exception(e)` at the two points where exceptions are caught and swallowed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DkHC7gGrP9sumqawjHLeLP

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error monitoring by capturing worker and batch-processing failures for diagnostic reporting.
  * Existing error handling and processing behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->