### PR TITLE
Log every pipeline that actually gets registered, and retire the deprecated classifier-choices shim

### DIFF
--- a/trapdata/antenna/registration.py
+++ b/trapdata/antenna/registration.py
@@ -7,7 +7,7 @@ from trapdata.antenna.schemas import (
     AsyncPipelineRegistrationRequest,
     AsyncPipelineRegistrationResponse,
 )
-from trapdata.api.api import CLASSIFIER_CHOICES, initialize_service_info
+from trapdata.api.api import initialize_service_info
 from trapdata.api.utils import get_http_session
 from trapdata.common.logs import logger
 from trapdata.settings import Settings, read_settings
@@ -134,7 +134,10 @@ def register_pipelines(
     successful_registrations = []
     failed_registrations = []
 
-    logger.info(f"Available pipelines to register: {list(CLASSIFIER_CHOICES.keys())}")
+    logger.info(
+        "Available pipelines to register: "
+        f"{[f'{config.slug} ({config.name})' for config in pipeline_configs]}"
+    )
 
     for project in projects_to_process:
         project_id = project["id"]

--- a/trapdata/api/api.py
+++ b/trapdata/api/api.py
@@ -213,27 +213,6 @@ _pipeline_choices = dict(zip(PIPELINE_CHOICES.keys(), list(PIPELINE_CHOICES.keys
 PipelineChoice = enum.Enum("PipelineChoice", _pipeline_choices)
 
 
-# DEPRECATED backward-compatibility projections of PIPELINE_CHOICES, kept for
-# call sites not yet migrated off the old shapes: registration, the api/tests
-# helpers, and cli/base.py still import CLASSIFIER_CHOICES as a
-# {slug: terminal_classifier} mapping. Both are DERIVED from PIPELINE_CHOICES —
-# never hand-maintained in parallel — so the two views cannot drift.
-#
-# CLASSIFIER_CHOICES intentionally covers only the default-detector
-# (APIMothDetector) pipelines, matching its historical contract. The anybug
-# pipeline uses APIAnyBugDetector and so is absent here; consumers that must see
-# every pipeline (the worker's subscription, validation, and dispatch) read
-# PIPELINE_CHOICES directly.
-#
-# TODO(anybug): migrate the remaining CLASSIFIER_CHOICES consumers onto
-# PIPELINE_CHOICES stage definitions, then delete this shim.
-CLASSIFIER_CHOICES: dict[str, type[APIMothClassifier]] = {
-    slug: pipeline.terminal
-    for slug, pipeline in PIPELINE_CHOICES.items()
-    if pipeline.detector is APIMothDetector
-}
-
-
 def top_label_for_algorithm(
     detection: DetectionResponse, algorithm_key: str
 ) -> str | None:

--- a/trapdata/api/tests/test_api.py
+++ b/trapdata/api/tests/test_api.py
@@ -5,7 +5,6 @@ from unittest import TestCase
 from fastapi.testclient import TestClient
 
 from trapdata.api.api import (
-    CLASSIFIER_CHOICES,
     PIPELINE_CHOICES,
     PipelineChoice,
     PipelineRequest,
@@ -100,7 +99,9 @@ class TestInferenceAPI(TestCase):
     def test_processing_with_only_binary_classifier(self):
         binary_classifier_pipeline_choice = "moth_binary"
         binary_algorithm_key = "moth_nonmoth_classifier"
-        BinaryAlgorithmClass = CLASSIFIER_CHOICES[binary_classifier_pipeline_choice]
+        BinaryAlgorithmClass = PIPELINE_CHOICES[
+            binary_classifier_pipeline_choice
+        ].terminal
         # Create an instance to get the num_classes
         binary_algorithm = BinaryAlgorithmClass(source_images=[], detections=[])
 

--- a/trapdata/api/tests/test_pipeline_registry.py
+++ b/trapdata/api/tests/test_pipeline_registry.py
@@ -861,27 +861,3 @@ def test_process_batch_tags_uncroppable_detection_instead_of_naked():
     assert _classifications_by_algorithm(d0) == {
         worker.UNCROPPABLE_ALGORITHM.key: (worker.UNCROPPABLE_LABEL, False)
     }
-
-
-def test_classifier_choices_projection_is_collision_free():
-    """CLASSIFIER_CHOICES is a DERIVED ``{slug: terminal}`` view of the
-    default-detector pipelines. Because it is keyed by the same unique slugs as
-    PIPELINE_CHOICES, deriving it can never merge two pipelines onto one slug or
-    drop one silently. Pin that so adding a pipeline keeps the projection 1:1.
-    """
-    from trapdata.api.api import CLASSIFIER_CHOICES
-
-    expected_slugs = {
-        slug
-        for slug, pipeline in PIPELINE_CHOICES.items()
-        if pipeline.detector is APIMothDetector
-    }
-    # Every default-detector pipeline appears exactly once, keyed by its slug...
-    assert set(CLASSIFIER_CHOICES) == expected_slugs
-    assert len(CLASSIFIER_CHOICES) == len(expected_slugs)
-    # ...its keys are a subset of the registry's unique slugs (no key can collide
-    # with another pipeline's)...
-    assert set(CLASSIFIER_CHOICES).issubset(PIPELINE_CHOICES)
-    # ...and each derived terminal matches its source pipeline (no cross-wiring).
-    for slug, terminal in CLASSIFIER_CHOICES.items():
-        assert terminal is PIPELINE_CHOICES[slug].terminal

--- a/trapdata/api/tests/utils.py
+++ b/trapdata/api/tests/utils.py
@@ -7,7 +7,7 @@ from unittest.mock import patch
 
 from fastapi.testclient import TestClient
 
-from trapdata.api.api import CLASSIFIER_CHOICES, APIMothClassifier
+from trapdata.api.api import PIPELINE_CHOICES, APIMothClassifier
 from trapdata.api.schemas import SourceImageRequest
 from trapdata.api.tests.image_server import StaticFileTestServer
 
@@ -77,7 +77,7 @@ def get_pipeline_class(
     Returns:
         APIMothClassifier class for the specified pipeline
     """
-    return CLASSIFIER_CHOICES[slug]
+    return PIPELINE_CHOICES[slug].terminal
 
 
 @contextmanager

--- a/trapdata/cli/base.py
+++ b/trapdata/cli/base.py
@@ -1,5 +1,5 @@
 import pathlib
-from typing import Annotated, Optional
+from typing import Optional
 
 import typer
 

--- a/trapdata/cli/base.py
+++ b/trapdata/cli/base.py
@@ -3,7 +3,6 @@ from typing import Annotated, Optional
 
 import typer
 
-from trapdata.api.api import CLASSIFIER_CHOICES
 from trapdata.cli import db, export, queue, settings, shell, show, test, worker
 from trapdata.db.base import get_session_class
 from trapdata.db.models.events import get_or_create_monitoring_sessions


### PR DESCRIPTION
**Stacked on #160.** This branches from `feat/anybug-detector` and targets it rather than `main`, so #160 stays reviewable on its own. Once #160 merges, this PR should be rebased onto `main`.

## Summary

When a worker registers its pipelines with Antenna, the log line describing what got registered was built from a different, narrower list than what actually gets sent. Registration always registers every configured pipeline, but the log line only listed the pipelines that use the original moth detector — so the newer general insect-detection pipeline was silently missing from the log even though it was being registered correctly. An operator watching the worker log would see a shorter pipeline list than what Antenna actually received, which is confusing when trying to confirm a deployment. This change makes the log line reflect the pipelines that are actually registered.

That narrower list was `CLASSIFIER_CHOICES`, a deprecated helper left over from before pipelines could use different detectors. It was already marked for removal in #160 once its last few call sites migrated. This PR finishes that migration and deletes it, so there is a single source of truth for "what pipelines exist" going forward. While cleaning up imports in that same file, a second, unrelated dead import was found two lines above and removed too.

### List of Changes

| # | Change (effect) | How |
|---|---|---|
| 1 | The worker log now lists every pipeline actually being registered with Antenna, including the general insect-detection pipeline, instead of a stale subset. | `trapdata/antenna/registration.py` now logs each entry of `pipeline_configs` (the list already used to perform registration) instead of the deprecated `CLASSIFIER_CHOICES` mapping. |
| 2 | No behavior change for the CLI; a dead import is removed. | `trapdata/cli/base.py` imported `CLASSIFIER_CHOICES` but never used it. |
| 3 | No behavior change for tests; they now read the same source of truth the application code uses. | `trapdata/api/tests/utils.py` and `trapdata/api/tests/test_api.py` now look up a pipeline's terminal classifier via `PIPELINE_CHOICES[slug].terminal` instead of the deprecated `CLASSIFIER_CHOICES[slug]`. |
| 4 | A test that existed only to pin the now-deleted shim's derivation logic is removed; it has no subject once the shim is gone. | Deleted `test_classifier_choices_projection_is_collision_free` from `trapdata/api/tests/test_pipeline_registry.py`. No other test in that file was touched. |
| 5 | The deprecated shim itself is gone. | Deleted the `CLASSIFIER_CHOICES` definition, its `DEPRECATED` comment block, and the `TODO(anybug)` note in `trapdata/api/api.py`. `PipelineDefinition` and `PIPELINE_CHOICES`, the actual source of truth, are unchanged. |
| 6 | One more unused import in the CLI entry point is gone, so a reader is not misled into thinking the module uses typed CLI annotations. This import predates this branch and is unrelated to the shim removal above. | `trapdata/cli/base.py` also imported `typing.Annotated`, which nothing in the file uses; `Optional`, which the file does use, is kept. |

### Why this is safe now

`CLASSIFIER_CHOICES` was a derived `{slug: terminal_classifier}` view of `PIPELINE_CHOICES` that only included pipelines using the original default detector, kept around so a few call sites didn't need to change when pipelines gained the ability to pair any detector with any classifier. It could never drift out of sync with `PIPELINE_CHOICES` on its own — it was always computed from it — but by construction it silently excluded any pipeline using a different detector, which is exactly what produced the under-reporting log line above.

Every remaining consumer has now been moved onto `PIPELINE_CHOICES` directly, which covers all pipelines regardless of detector. With no consumers left, there is nothing to derive, and the log line can no longer omit a real pipeline.

Out of scope: `trapdata/api/demo.py` defines its own unrelated, module-level `CLASSIFIER_CHOICES` (a list of Gradio tab configs, not the API's slug mapping) and never imports the name from `trapdata.api.api`. It is untouched.

## Verified

- `grep -rn "CLASSIFIER_CHOICES" --include="*.py" .` returns only `trapdata/api/demo.py`'s unrelated local definition and its two local uses.
- `grep -c "Annotated" trapdata/cli/base.py` returns 0, confirming the second dead import is gone and nothing else in the file references it.
- `python -m pytest trapdata/api/tests/test_pipeline_registry.py trapdata/api/tests/test_api.py -q` — 31 passed, 0 failed. Neither test file imports `trapdata/cli/base.py`, so the `Annotated` removal cannot affect this count.
- `python -m compileall` and a real `import trapdata.cli.base` on every touched file — succeeded.
- `black --check` and `flake8` on every touched file — clean. One pre-existing, unrelated finding on `main`/`feat/anybug-detector` remains out of scope and was left as-is: an isort import-wrapping style diff in `trapdata/api/api.py`.
- Full diff reviewed; only the five call sites, the shim definition, and the one extra dead import changed.

Co-Authored-By: Claude <noreply@anthropic.com>

---
_Generated by [Claude Code](https://claude.ai/code/session_01A3zBxvt6iqCiaZVJMCaFCk)_
