### PR TITLE
Let workers drain and restart cleanly before leaked memory takes down the host

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,7 +20,15 @@ AMI_ANTENNA_SERVICE_NAME="AMI Data Companion"
 # boundary when it receives SIGUSR1 (e.g. `supervisorctl signal USR1 <program>`),
 # after processing AMI_WORKER_MAX_JOBS jobs, or when its resident memory,
 # sampled between jobs, exceeds AMI_WORKER_MAX_RSS_MB (in MiB). 0 disables
-# either cap. All rely on a process supervisor (supervisord, systemd, docker
-# restart policy) to start a fresh worker afterwards.
+# either cap.
+#
+# Recycling requires a process manager configured to restart the worker after
+# a *successful* exit, because a drain exits with status 0. The usual defaults
+# do not: supervisord's `autorestart=unexpected` and systemd's
+# `Restart=on-failure` both treat status 0 as a reason to stay stopped, as
+# does Docker's `on-failure` restart policy. Set `autorestart=true`
+# (supervisord), `Restart=always` (systemd), or `--restart always` /
+# `unless-stopped` (Docker). Without it the worker recycles once and stays
+# down.
 # AMI_WORKER_MAX_JOBS=10
 # AMI_WORKER_MAX_RSS_MB=8192

--- a/.env.example
+++ b/.env.example
@@ -18,7 +18,9 @@ AMI_ANTENNA_SERVICE_NAME="AMI Data Companion"
 
 # Worker process recycling. The worker exits cleanly at the next batch
 # boundary when it receives SIGUSR1 (e.g. `supervisorctl signal USR1 <program>`),
-# or when its resident memory, sampled between jobs, exceeds this cap in MiB.
-# 0 disables the memory cap. Both rely on a process supervisor (supervisord,
-# systemd, docker restart policy) to start a fresh worker afterwards.
+# after processing AMI_WORKER_MAX_JOBS jobs, or when its resident memory,
+# sampled between jobs, exceeds AMI_WORKER_MAX_RSS_MB (in MiB). 0 disables
+# either cap. All rely on a process supervisor (supervisord, systemd, docker
+# restart policy) to start a fresh worker afterwards.
+# AMI_WORKER_MAX_JOBS=10
 # AMI_WORKER_MAX_RSS_MB=8192

--- a/.env.example
+++ b/.env.example
@@ -19,8 +19,8 @@ AMI_ANTENNA_SERVICE_NAME="AMI Data Companion"
 # Worker process recycling. The worker exits cleanly at the next batch
 # boundary when it receives SIGUSR1 (e.g. `supervisorctl signal USR1 <program>`),
 # after processing AMI_WORKER_MAX_JOBS jobs, or when its resident memory,
-# sampled between jobs, exceeds AMI_WORKER_MAX_RSS_MB (in MiB). 0 disables
-# either cap.
+# sampled between jobs, reaches or exceeds AMI_WORKER_MAX_RSS_MB (in MiB).
+# 0 disables either cap.
 #
 # Recycling requires a process manager configured to restart the worker after
 # a *successful* exit, because a drain exits with status 0. The usual defaults

--- a/.env.example
+++ b/.env.example
@@ -15,3 +15,10 @@ AMI_ANTENNA_API_BASE_URL=http://localhost:8000/api/v2
 AMI_ANTENNA_API_AUTH_TOKEN=your_antenna_auth_token_here
 AMI_ANTENNA_API_BATCH_SIZE=4
 AMI_ANTENNA_SERVICE_NAME="AMI Data Companion"
+
+# Worker process recycling. The worker exits cleanly at the next batch
+# boundary when it receives SIGUSR1 (e.g. `supervisorctl signal USR1 <program>`),
+# or when its resident memory, sampled between jobs, exceeds this cap in MiB.
+# 0 disables the memory cap. Both rely on a process supervisor (supervisord,
+# systemd, docker restart policy) to start a fresh worker afterwards.
+# AMI_WORKER_MAX_RSS_MB=8192

--- a/trapdata/antenna/tests/test_worker_drain.py
+++ b/trapdata/antenna/tests/test_worker_drain.py
@@ -101,9 +101,10 @@ class TestParentDrainPropagation(TestCase):
         assert drain.reason is None
 
     def test_own_reason_survives_a_parent_event(self):
-        drain = _DrainRequest(_spawn_event())
+        event = _spawn_event()
+        drain = _DrainRequest(event)
         drain.request("SIGUSR1")
-        drain._parent_event.set()
+        event.set()
         assert drain.reason == "SIGUSR1"
 
     @unittest.skipUnless(_HAS_SIGUSR1, "platform has no SIGUSR1")

--- a/trapdata/antenna/tests/test_worker_drain.py
+++ b/trapdata/antenna/tests/test_worker_drain.py
@@ -10,6 +10,7 @@ loop exits after a drain request. No models are loaded; inference is mocked
 out.
 """
 
+import multiprocessing
 import os
 import signal
 import unittest
@@ -22,11 +23,17 @@ from trapdata.antenna.worker import (
     _current_rss_bytes,
     _DrainRequest,
     _install_drain_handler,
+    _install_parent_drain_handler,
     _process_job,
     _worker_loop,
 )
 
 _HAS_SIGUSR1 = hasattr(signal, "SIGUSR1")
+
+
+def _spawn_event():
+    """An event of the kind the parent shares with spawned worker instances."""
+    return multiprocessing.get_context("spawn").Event()
 
 
 class TestDrainRequest(TestCase):
@@ -56,6 +63,58 @@ class TestDrainRequest(TestCase):
             _install_drain_handler(drain)
             os.kill(os.getpid(), signal.SIGUSR1)
             assert drain.requested
+        finally:
+            signal.signal(signal.SIGUSR1, previous)
+
+
+class TestParentDrainPropagation(TestCase):
+    """A drain reaches a worker instance even if it arrives before that
+    instance is ready to handle a signal.
+
+    Worker instances are started with the spawn method, so each begins life
+    with SIGUSR1 at its default action of terminating the process. The parent
+    therefore never signals them: it sets a shared event that each instance
+    reads at its own safe points. The guarantee under test is that an event
+    already set when the instance starts is honoured, which is exactly the
+    case a signal could not survive.
+    """
+
+    def test_event_set_before_start_is_observed(self):
+        event = _spawn_event()
+        event.set()
+        drain = _DrainRequest(event)
+        assert drain.requested
+        assert "parent" in drain.reason
+
+    def test_event_set_after_start_is_observed(self):
+        event = _spawn_event()
+        drain = _DrainRequest(event)
+        assert not drain.requested
+        event.set()
+        assert drain.requested
+
+    def test_unset_event_does_not_request_a_drain(self):
+        # Without this, an always-true `requested` would pass the positive
+        # cases above while draining every worker immediately.
+        drain = _DrainRequest(_spawn_event())
+        assert not drain.requested
+        assert drain.reason is None
+
+    def test_own_reason_survives_a_parent_event(self):
+        drain = _DrainRequest(_spawn_event())
+        drain.request("SIGUSR1")
+        drain._parent_event.set()
+        assert drain.reason == "SIGUSR1"
+
+    @unittest.skipUnless(_HAS_SIGUSR1, "platform has no SIGUSR1")
+    def test_parent_handler_publishes_to_the_event(self):
+        event = _spawn_event()
+        previous = signal.getsignal(signal.SIGUSR1)
+        try:
+            _install_parent_drain_handler(event)
+            assert not event.is_set()
+            os.kill(os.getpid(), signal.SIGUSR1)
+            assert event.is_set()
         finally:
             signal.signal(signal.SIGUSR1, previous)
 
@@ -133,6 +192,32 @@ class TestAfterJobCheck(TestCase):
         if rss is None:
             self.skipTest("/proc/self/status not available on this platform")
         assert rss > 0
+
+
+class TestRecycleCapValidation(TestCase):
+    """Only 0 disables a recycle cap.
+
+    A negative value would otherwise be accepted and read as "disabled" by
+    the threshold checks, quietly turning off a cap an operator meant to set.
+    """
+
+    def test_negative_caps_are_rejected(self):
+        import pydantic
+
+        from trapdata.settings import Settings
+
+        for field in ("worker_max_rss_mb", "worker_max_jobs"):
+            with self.subTest(field=field):
+                with self.assertRaises(pydantic.ValidationError):
+                    Settings(**{field: -1})
+
+    def test_zero_and_positive_caps_are_accepted(self):
+        from trapdata.settings import Settings
+
+        for value in (0, 4096):
+            settings = Settings(worker_max_rss_mb=value, worker_max_jobs=value)
+            assert settings.worker_max_rss_mb == value
+            assert settings.worker_max_jobs == value
 
 
 def _fake_batches(n: int) -> list[dict]:
@@ -262,3 +347,33 @@ class TestWorkerLoopExitsOnDrain(TestCase):
             signal.signal(signal.SIGUSR1, previous)
 
         assert polls == [1]
+
+    @patch("trapdata.antenna.worker.get_jobs")
+    @patch("trapdata.antenna.worker.read_settings")
+    def test_loop_honours_a_drain_requested_before_it_started(
+        self, mock_read_settings, mock_get_jobs
+    ):
+        """A worker instance started after the parent already drained exits
+        without claiming a job.
+
+        This is the startup case a forwarded signal cannot cover: the parent
+        may drain while an instance is still starting, before that instance
+        can handle SIGUSR1.
+        """
+        settings = MagicMock()
+        settings.antenna_service_name = "test-worker"
+        settings.worker_max_rss_mb = 0
+        settings.worker_max_jobs = 0
+        mock_read_settings.return_value = settings
+
+        event = _spawn_event()
+        event.set()
+
+        previous = signal.getsignal(signal.SIGUSR1) if _HAS_SIGUSR1 else None
+        try:
+            _worker_loop(0, ["fake_pipeline"], event)
+        finally:
+            if _HAS_SIGUSR1:
+                signal.signal(signal.SIGUSR1, previous)
+
+        mock_get_jobs.assert_not_called()

--- a/trapdata/antenna/tests/test_worker_drain.py
+++ b/trapdata/antenna/tests/test_worker_drain.py
@@ -155,6 +155,14 @@ class TestAfterJobCheck(TestCase):
         # 9 GiB = 9216 MiB, over an 8192 MiB cap
         assert "9216" in drain.reason
 
+    @patch("trapdata.antenna.worker._current_rss_bytes", return_value=8 * 1024**3)
+    def test_rss_exactly_at_cap_requests_drain(self, _rss):
+        # The cap is inclusive, which is what the setting's documentation
+        # promises operators.
+        drain = _DrainRequest()
+        _after_job_check(drain, _recycle_settings(max_rss_mb=8192), jobs_processed=1)
+        assert drain.requested
+
     @patch("trapdata.antenna.worker._current_rss_bytes", return_value=2 * 1024**3)
     def test_rss_under_cap_does_nothing(self, _rss):
         drain = _DrainRequest()

--- a/trapdata/antenna/tests/test_worker_drain.py
+++ b/trapdata/antenna/tests/test_worker_drain.py
@@ -1,0 +1,219 @@
+"""Unit tests for the worker's drain-and-exit machinery.
+
+The worker exits at a batch boundary — never mid-batch — when an operator
+sends SIGUSR1 or when its resident memory, sampled between jobs, exceeds the
+``AMI_WORKER_MAX_RSS_MB`` cap. These tests cover the drain state and signal
+handler, the memory-cap check, that ``_process_job`` stops cleanly at a batch
+boundary while flushing pending result posts, and that the polling loop exits
+after a drain request. No models are loaded; inference is mocked out.
+"""
+
+import os
+import signal
+import unittest
+from types import SimpleNamespace
+from unittest import TestCase
+from unittest.mock import MagicMock, patch
+
+from trapdata.antenna.worker import (
+    _check_rss_cap,
+    _current_rss_bytes,
+    _DrainRequest,
+    _install_drain_handler,
+    _process_job,
+    _worker_loop,
+)
+
+_HAS_SIGUSR1 = hasattr(signal, "SIGUSR1")
+
+
+class TestDrainRequest(TestCase):
+    def test_starts_unrequested(self):
+        drain = _DrainRequest()
+        assert not drain.requested
+        assert drain.reason is None
+
+    def test_signal_handler_sets_requested(self):
+        drain = _DrainRequest()
+        # The handler ignores its (signum, frame) arguments.
+        drain.handle_signal(None, None)
+        assert drain.requested
+        assert drain.reason == "SIGUSR1"
+
+    def test_first_reason_is_kept(self):
+        drain = _DrainRequest()
+        drain.request("first")
+        drain.request("second")
+        assert drain.reason == "first"
+
+    @unittest.skipUnless(_HAS_SIGUSR1, "platform has no SIGUSR1")
+    def test_installed_handler_receives_a_real_signal(self):
+        drain = _DrainRequest()
+        previous = signal.getsignal(signal.SIGUSR1)
+        try:
+            _install_drain_handler(drain)
+            os.kill(os.getpid(), signal.SIGUSR1)
+            assert drain.requested
+        finally:
+            signal.signal(signal.SIGUSR1, previous)
+
+
+class TestRssCap(TestCase):
+    def test_zero_cap_disables_the_check(self):
+        drain = _DrainRequest()
+        _check_rss_cap(drain, 0)
+        assert not drain.requested
+
+    @patch("trapdata.antenna.worker._current_rss_bytes", return_value=9 * 1024**3)
+    def test_over_cap_requests_drain(self, _rss):
+        drain = _DrainRequest()
+        _check_rss_cap(drain, 8192)
+        assert drain.requested
+        # 9 GiB = 9216 MiB, over an 8192 MiB cap
+        assert "9216" in drain.reason
+
+    @patch("trapdata.antenna.worker._current_rss_bytes", return_value=2 * 1024**3)
+    def test_under_cap_does_nothing(self, _rss):
+        drain = _DrainRequest()
+        _check_rss_cap(drain, 8192)
+        assert not drain.requested
+
+    @patch("trapdata.antenna.worker._current_rss_bytes", return_value=None)
+    def test_unreadable_rss_is_skipped(self, _rss):
+        drain = _DrainRequest()
+        _check_rss_cap(drain, 8192)
+        assert not drain.requested
+
+    def test_current_rss_reads_a_positive_value_where_proc_exists(self):
+        rss = _current_rss_bytes()
+        if rss is None:
+            self.skipTest("/proc/self/status not available on this platform")
+        assert rss > 0
+
+
+def _fake_batches(n: int) -> list[dict]:
+    """Minimal truthy batches; contents are irrelevant with inference mocked."""
+    return [{"images": [object()], "image_ids": [f"img_{i}"]} for i in range(n)]
+
+
+@patch("trapdata.antenna.worker.ResultPoster")
+@patch("trapdata.antenna.worker.APIMothDetector")
+@patch("trapdata.antenna.worker._process_batch", return_value=(1, 0, [], 0.0, 0.0))
+@patch("trapdata.antenna.worker.should_filter_detections", return_value=False)
+@patch.dict(
+    "trapdata.antenna.worker.CLASSIFIER_CHOICES",
+    {"fake_pipeline": MagicMock()},
+)
+@patch("trapdata.antenna.worker.get_rest_dataloader")
+class TestProcessJobStopsAtBatchBoundary(TestCase):
+    """``should_stop`` must stop a job between batches, never lose posted work.
+
+    The guard has to hold in both directions: with a stop requested after the
+    first batch, later batches must not run; without one, every batch must
+    run — otherwise a should_stop that always trips would pass the first
+    assertion while silently truncating every job.
+    """
+
+    def _settings(self) -> MagicMock:
+        settings = MagicMock()
+        settings.antenna_api_base_url = "http://testserver/api/v2"
+        settings.antenna_api_auth_token = "test-token"
+        return settings
+
+    def _give_poster_real_metrics(self, mock_poster_cls: MagicMock) -> None:
+        # The end-of-job summary formats these with numeric format specs,
+        # which a bare MagicMock attribute cannot satisfy.
+        mock_poster_cls.return_value.get_metrics.return_value = SimpleNamespace(
+            total_posts=1,
+            successful_posts=1,
+            failed_posts=0,
+            success_rate=100.0,
+            total_post_time=0.1,
+            max_queue_size=1,
+        )
+
+    def test_stops_after_current_batch(
+        self,
+        mock_loader,
+        mock_should_filter,
+        mock_process_batch,
+        mock_detector,
+        mock_poster_cls,
+    ):
+        mock_loader.return_value = _fake_batches(3)
+        self._give_poster_real_metrics(mock_poster_cls)
+
+        stop_flag = {"stop": False}
+
+        def on_batch(batch_num: int, items: int):
+            # Simulates a drain request arriving while batch 1 is in flight.
+            stop_flag["stop"] = True
+
+        result = _process_job(
+            "fake_pipeline",
+            job_id=123,
+            settings=self._settings(),
+            on_batch_complete=on_batch,
+            should_stop=lambda: stop_flag["stop"],
+        )
+
+        assert result is True
+        # Batch 1 ran; batches 2 and 3 were left for the next worker.
+        assert mock_process_batch.call_count == 1
+        # Pending posts were flushed and the poster shut down cleanly.
+        poster = mock_poster_cls.return_value
+        poster.wait_for_all_posts.assert_called_once()
+        poster.shutdown.assert_called_once()
+
+    def test_without_stop_request_all_batches_run(
+        self,
+        mock_loader,
+        mock_should_filter,
+        mock_process_batch,
+        mock_detector,
+        mock_poster_cls,
+    ):
+        mock_loader.return_value = _fake_batches(3)
+        self._give_poster_real_metrics(mock_poster_cls)
+
+        result = _process_job(
+            "fake_pipeline",
+            job_id=123,
+            settings=self._settings(),
+            should_stop=lambda: False,
+        )
+
+        assert result is True
+        assert mock_process_batch.call_count == 3
+
+
+class TestWorkerLoopExitsOnDrain(TestCase):
+    @unittest.skipUnless(_HAS_SIGUSR1, "platform has no SIGUSR1")
+    @patch("trapdata.antenna.worker.get_jobs")
+    @patch("trapdata.antenna.worker.read_settings")
+    def test_loop_returns_after_signal(self, mock_read_settings, mock_get_jobs):
+        settings = MagicMock()
+        settings.antenna_service_name = "test-worker"
+        settings.worker_max_rss_mb = 0
+        mock_read_settings.return_value = settings
+
+        polls: list[int] = []
+
+        def fake_get_jobs(**kwargs):
+            polls.append(1)
+            if len(polls) > 1:
+                raise AssertionError("worker loop kept polling after the drain request")
+            # The signal is delivered to this process before get_jobs returns,
+            # like an operator signalling mid-poll.
+            os.kill(os.getpid(), signal.SIGUSR1)
+            return []
+
+        mock_get_jobs.side_effect = fake_get_jobs
+
+        previous = signal.getsignal(signal.SIGUSR1)
+        try:
+            _worker_loop(0, ["fake_pipeline"])
+        finally:
+            signal.signal(signal.SIGUSR1, previous)
+
+        assert polls == [1]

--- a/trapdata/antenna/tests/test_worker_drain.py
+++ b/trapdata/antenna/tests/test_worker_drain.py
@@ -1,11 +1,13 @@
 """Unit tests for the worker's drain-and-exit machinery.
 
 The worker exits at a batch boundary — never mid-batch — when an operator
-sends SIGUSR1 or when its resident memory, sampled between jobs, exceeds the
-``AMI_WORKER_MAX_RSS_MB`` cap. These tests cover the drain state and signal
-handler, the memory-cap check, that ``_process_job`` stops cleanly at a batch
-boundary while flushing pending result posts, and that the polling loop exits
-after a drain request. No models are loaded; inference is mocked out.
+sends SIGUSR1, after ``AMI_WORKER_MAX_JOBS`` jobs, or when its resident
+memory, sampled between jobs, exceeds ``AMI_WORKER_MAX_RSS_MB``. These tests
+cover the drain state and signal handler, the between-jobs recycle checks
+and their per-job memory log line, that ``_process_job`` stops cleanly at a
+batch boundary while flushing pending result posts, and that the polling
+loop exits after a drain request. No models are loaded; inference is mocked
+out.
 """
 
 import os
@@ -16,7 +18,7 @@ from unittest import TestCase
 from unittest.mock import MagicMock, patch
 
 from trapdata.antenna.worker import (
-    _check_rss_cap,
+    _after_job_check,
     _current_rss_bytes,
     _DrainRequest,
     _install_drain_handler,
@@ -58,31 +60,73 @@ class TestDrainRequest(TestCase):
             signal.signal(signal.SIGUSR1, previous)
 
 
-class TestRssCap(TestCase):
-    def test_zero_cap_disables_the_check(self):
+def _recycle_settings(max_rss_mb: int = 0, max_jobs: int = 0) -> SimpleNamespace:
+    return SimpleNamespace(worker_max_rss_mb=max_rss_mb, worker_max_jobs=max_jobs)
+
+
+class TestAfterJobCheck(TestCase):
+    """Each recycle cap must trigger only past its threshold and stay off at 0.
+
+    Both directions matter: a cap that never fires leaves memory growth
+    unbounded, and a cap that fires with the triggers disabled would recycle
+    every deployment that did not opt in.
+    """
+
+    @patch("trapdata.antenna.worker._current_rss_bytes", return_value=2 * 1024**3)
+    def test_default_caps_never_request_drain(self, _rss):
         drain = _DrainRequest()
-        _check_rss_cap(drain, 0)
+        _after_job_check(drain, _recycle_settings(), jobs_processed=100)
         assert not drain.requested
 
+    @patch("trapdata.antenna.worker._current_rss_bytes", return_value=2 * 1024**3)
+    def test_rss_per_job_line_is_always_logged(self, _rss):
+        # The log line is the instrument for answering whether memory climbs
+        # job after job in a deployment, so it must not depend on any cap
+        # being enabled.
+        with patch("trapdata.antenna.worker.logger") as mock_logger:
+            _after_job_check(_DrainRequest(), _recycle_settings(), jobs_processed=3)
+        logged = " ".join(str(c.args[0]) for c in mock_logger.info.call_args_list)
+        assert "Resident memory after job 3: 2048 MiB" in logged
+
     @patch("trapdata.antenna.worker._current_rss_bytes", return_value=9 * 1024**3)
-    def test_over_cap_requests_drain(self, _rss):
+    def test_rss_over_cap_requests_drain(self, _rss):
         drain = _DrainRequest()
-        _check_rss_cap(drain, 8192)
+        _after_job_check(drain, _recycle_settings(max_rss_mb=8192), jobs_processed=1)
         assert drain.requested
         # 9 GiB = 9216 MiB, over an 8192 MiB cap
         assert "9216" in drain.reason
 
     @patch("trapdata.antenna.worker._current_rss_bytes", return_value=2 * 1024**3)
-    def test_under_cap_does_nothing(self, _rss):
+    def test_rss_under_cap_does_nothing(self, _rss):
         drain = _DrainRequest()
-        _check_rss_cap(drain, 8192)
+        _after_job_check(drain, _recycle_settings(max_rss_mb=8192), jobs_processed=1)
         assert not drain.requested
 
     @patch("trapdata.antenna.worker._current_rss_bytes", return_value=None)
-    def test_unreadable_rss_is_skipped(self, _rss):
+    def test_unreadable_rss_skips_the_memory_cap(self, _rss):
         drain = _DrainRequest()
-        _check_rss_cap(drain, 8192)
+        _after_job_check(drain, _recycle_settings(max_rss_mb=8192), jobs_processed=1)
         assert not drain.requested
+
+    @patch("trapdata.antenna.worker._current_rss_bytes", return_value=None)
+    def test_job_cap_works_without_rss(self, _rss):
+        drain = _DrainRequest()
+        _after_job_check(drain, _recycle_settings(max_jobs=5), jobs_processed=5)
+        assert drain.requested
+        assert "cap 5" in drain.reason
+
+    @patch("trapdata.antenna.worker._current_rss_bytes", return_value=2 * 1024**3)
+    def test_job_cap_not_reached_does_nothing(self, _rss):
+        drain = _DrainRequest()
+        _after_job_check(drain, _recycle_settings(max_jobs=5), jobs_processed=4)
+        assert not drain.requested
+
+    @patch("trapdata.antenna.worker._current_rss_bytes", return_value=2 * 1024**3)
+    def test_existing_drain_reason_is_kept(self, _rss):
+        drain = _DrainRequest()
+        drain.request("SIGUSR1")
+        _after_job_check(drain, _recycle_settings(max_jobs=1), jobs_processed=1)
+        assert drain.reason == "SIGUSR1"
 
     def test_current_rss_reads_a_positive_value_where_proc_exists(self):
         rss = _current_rss_bytes()
@@ -195,6 +239,7 @@ class TestWorkerLoopExitsOnDrain(TestCase):
         settings = MagicMock()
         settings.antenna_service_name = "test-worker"
         settings.worker_max_rss_mb = 0
+        settings.worker_max_jobs = 0
         mock_read_settings.return_value = settings
 
         polls: list[int] = []

--- a/trapdata/antenna/worker.py
+++ b/trapdata/antenna/worker.py
@@ -38,8 +38,8 @@ class _DrainRequest:
     """A request for the worker process to exit at the next safe point.
 
     Set by SIGUSR1 (an operator or process supervisor asking for a recycle)
-    or by the worker itself when its resident memory, sampled between jobs,
-    exceeds the ``worker_max_rss_mb`` cap. A safe point is a batch boundary:
+    or by the worker itself when a between-jobs recycle cap is hit — see
+    ``_after_job_check``. A safe point is a batch boundary:
     the batch in flight finishes and its results are posted before the
     process exits with status 0, so a process supervisor restarts a fresh
     worker (fresh memory, file descriptors, and DataLoader state) without
@@ -84,21 +84,43 @@ def _current_rss_bytes() -> int | None:
     return None
 
 
-def _check_rss_cap(drain: _DrainRequest, max_rss_mb: int) -> None:
-    """Request a drain when resident memory exceeds the configured cap.
+def _after_job_check(
+    drain: _DrainRequest, settings: Settings, jobs_processed: int
+) -> None:
+    """Log per-job memory and request a drain when a recycle cap is hit.
 
-    Called between jobs, when the working set is at its idle baseline, so a
-    reading over the cap indicates memory that survived per-job cleanup
-    rather than a job's transient working set. A cap of 0 (the default)
-    disables the check.
+    Runs between jobs, when the working set is at its idle baseline, so the
+    logged reading — and the ``worker_max_rss_mb`` comparison — reflects
+    memory retained across jobs rather than a job's transient working set.
+    The log line lets operators answer "does resident memory keep climbing
+    job after job, or plateau after the first model load?" from ordinary
+    worker logs, without instrumenting the host.
+
+    Two independent triggers, each disabled at 0 (the default):
+
+    - ``worker_max_jobs``: drain after this many jobs. Deterministic bound
+      for retention that scales with jobs processed, useful even before the
+      retained memory's size or source is known.
+    - ``worker_max_rss_mb``: drain when resident memory exceeds this many
+      MiB. Catches whatever the job cap does not predict.
     """
-    if max_rss_mb <= 0 or drain.requested:
-        return
     rss_bytes = _current_rss_bytes()
-    if rss_bytes is None:
+    rss_mb = rss_bytes // _MIB if rss_bytes is not None else None
+    if rss_mb is not None:
+        logger.info(f"Resident memory after job {jobs_processed}: {rss_mb} MiB")
+    if drain.requested:
         return
-    rss_mb = rss_bytes // _MIB
-    if rss_mb >= max_rss_mb:
+    max_jobs = settings.worker_max_jobs
+    if max_jobs > 0 and jobs_processed >= max_jobs:
+        logger.info(
+            f"Processed {jobs_processed} jobs, reaching the "
+            f"{max_jobs}-job cap (AMI_WORKER_MAX_JOBS); exiting cleanly so "
+            "the process supervisor restarts a fresh worker"
+        )
+        drain.request(f"{jobs_processed} jobs processed, cap {max_jobs}")
+        return
+    max_rss_mb = settings.worker_max_rss_mb
+    if max_rss_mb > 0 and rss_mb is not None and rss_mb >= max_rss_mb:
         logger.warning(
             f"Resident memory {rss_mb} MiB is over the {max_rss_mb} MiB cap "
             "(AMI_WORKER_MAX_RSS_MB); exiting cleanly so the process "
@@ -164,9 +186,9 @@ def run_worker(pipelines: list[str]):
 def _worker_loop(gpu_id: int, pipelines: list[str]):
     """Main polling loop for a single AMI worker instance, pinned to a specific GPU.
 
-    The loop runs until a drain is requested — by SIGUSR1 or by the
-    between-jobs resident-memory cap — and then returns so the process exits
-    with status 0 for its supervisor to restart.
+    The loop runs until a drain is requested — by SIGUSR1 or by a
+    between-jobs recycle cap (see ``_after_job_check``) — and then returns
+    so the process exits with status 0 for its supervisor to restart.
 
     Args:
         gpu_id: GPU index to pin this AMI worker instance to (0 for CPU-only).
@@ -186,6 +208,7 @@ def _worker_loop(gpu_id: int, pipelines: list[str]):
     full_service_name = get_full_service_name(settings.antenna_service_name)
     logger.info(f"Running worker as: {full_service_name}")
 
+    jobs_processed = 0
     while not drain.requested:
         # TODO CGJS: Support pulling and prioritizing single image tasks, which are used in interactive testing
         # These should probably come from a dedicated endpoint and should preempt batch jobs under the assumption that they
@@ -205,6 +228,11 @@ def _worker_loop(gpu_id: int, pipelines: list[str]):
             logger.info(
                 f"[GPU {gpu_id}] Processing job {job_id} with pipeline {pipeline}"
             )
+            # A job that raised mid-processing still counts toward the
+            # recycle caps: it may have loaded models and run batches, so
+            # it retains memory like a completed job. Claims that yielded
+            # no work do not count.
+            work_attempted = False
             try:
                 any_work_done = _process_job(
                     pipeline=pipeline,
@@ -214,15 +242,17 @@ def _worker_loop(gpu_id: int, pipelines: list[str]):
                     should_stop=lambda: drain.requested,
                 )
                 any_jobs = any_jobs or any_work_done
+                work_attempted = any_work_done
             except Exception as e:
                 logger.error(
                     f"[GPU {gpu_id}] Failed to process job {job_id} with pipeline {pipeline}: {e}",
                     exc_info=True,
                 )
                 # Continue to next job rather than crashing the worker
-            # Between jobs the working set is at its baseline, so this is
-            # where leaked memory is distinguishable from a busy working set.
-            _check_rss_cap(drain, settings.worker_max_rss_mb)
+                work_attempted = True
+            if work_attempted:
+                jobs_processed += 1
+                _after_job_check(drain, settings, jobs_processed)
 
         if not any_jobs and not drain.requested:
             logger.info(

--- a/trapdata/antenna/worker.py
+++ b/trapdata/antenna/worker.py
@@ -140,7 +140,7 @@ def _after_job_check(
     - ``worker_max_jobs``: drain after this many jobs. Deterministic bound
       for retention that scales with jobs processed, useful even before the
       retained memory's size or source is known.
-    - ``worker_max_rss_mb``: drain when resident memory exceeds this many
+    - ``worker_max_rss_mb``: drain when resident memory reaches this many
       MiB. Catches whatever the job cap does not predict.
     """
     rss_bytes = _current_rss_bytes()
@@ -161,11 +161,11 @@ def _after_job_check(
     max_rss_mb = settings.worker_max_rss_mb
     if max_rss_mb > 0 and rss_mb is not None and rss_mb >= max_rss_mb:
         logger.warning(
-            f"Resident memory {rss_mb} MiB is over the {max_rss_mb} MiB cap "
+            f"Resident memory {rss_mb} MiB reached the {max_rss_mb} MiB cap "
             "(AMI_WORKER_MAX_RSS_MB); exiting cleanly so the process "
             "supervisor restarts a fresh worker"
         )
-        drain.request(f"resident memory {rss_mb} MiB over the {max_rss_mb} MiB cap")
+        drain.request(f"resident memory {rss_mb} MiB reached the {max_rss_mb} MiB cap")
 
 
 def run_worker(pipelines: list[str]):

--- a/trapdata/antenna/worker.py
+++ b/trapdata/antenna/worker.py
@@ -3,10 +3,11 @@
 from __future__ import annotations
 
 import datetime
-import os
 import signal
 import time
 from collections.abc import Callable
+from multiprocessing.synchronize import Event as EventType
+from types import FrameType
 
 import numpy as np
 import torch
@@ -37,20 +38,28 @@ _MIB = 1024 * 1024
 class _DrainRequest:
     """A request for the worker process to exit at the next safe point.
 
-    Set by SIGUSR1 (an operator or process supervisor asking for a recycle)
-    or by the worker itself when a between-jobs recycle cap is hit — see
-    ``_after_job_check``. A safe point is a batch boundary:
-    the batch in flight finishes and its results are posted before the
-    process exits with status 0, so a process supervisor restarts a fresh
-    worker (fresh memory, file descriptors, and DataLoader state) without
-    losing in-flight work.
+    Set by SIGUSR1 (an operator or process supervisor asking for a recycle),
+    by the worker itself when a between-jobs recycle cap is hit (see
+    ``_after_job_check``), or by the parent of a multi-GPU worker group
+    through ``parent_event``. A safe point is a batch boundary: the batch in
+    flight finishes and its results are posted before the process exits with
+    status 0, so a process manager configured to restart the worker after a
+    clean exit starts a fresh one (fresh memory, file descriptors, and
+    DataLoader state) without losing in-flight work.
     """
 
-    def __init__(self) -> None:
+    def __init__(self, parent_event: EventType | None = None) -> None:
         self.reason: str | None = None
+        self._parent_event = parent_event
 
     @property
     def requested(self) -> bool:
+        # Reading the parent's event here means every safe point already in
+        # the worker — the polling loop and the batch-boundary
+        # ``should_stop`` — observes a drain published by the parent without
+        # having to check for it separately.
+        if self._parent_event is not None and self._parent_event.is_set():
+            self.request("parent process requested a drain")
         return self.reason is not None
 
     def request(self, reason: str) -> None:
@@ -58,7 +67,7 @@ class _DrainRequest:
         if self.reason is None:
             self.reason = reason
 
-    def handle_signal(self, signum, frame) -> None:
+    def handle_signal(self, signum: int, frame: FrameType | None) -> None:
         logger.info(
             "SIGUSR1 received: will finish the batch in flight, post its "
             "results, and exit cleanly"
@@ -70,6 +79,36 @@ def _install_drain_handler(drain: _DrainRequest) -> None:
     """Route SIGUSR1 to ``drain`` on platforms that have the signal."""
     if hasattr(signal, "SIGUSR1"):
         signal.signal(signal.SIGUSR1, drain.handle_signal)
+
+
+def _install_parent_drain_handler(drain_event: EventType) -> None:
+    """Let the parent of a worker group publish drains without signalling children.
+
+    The parent owns SIGUSR1 on behalf of the whole group, because signalling
+    the children directly is unsafe during their startup: they are started
+    with the spawn method, so each begins life with SIGUSR1 at its default
+    action of terminating the process and only installs its own handler once
+    ``_worker_loop`` runs. A signal landing in that window kills the child,
+    and torch responds by terminating its siblings — the opposite of a clean
+    drain. Publishing the request through an event the children read at their
+    own safe points removes that window rather than narrowing it.
+
+    Installing this before any child is spawned also closes the matching
+    window in the parent, which is otherwise still at SIGUSR1's default
+    action while its children are already running, so a drain arriving then
+    would kill the parent and orphan workers holding GPU memory.
+    """
+    if not hasattr(signal, "SIGUSR1"):
+        return
+
+    def _publish_drain(signum: int, frame: FrameType | None) -> None:
+        logger.info(
+            "SIGUSR1 received: asking every worker instance to finish the "
+            "batch in flight, post its results, and exit cleanly"
+        )
+        drain_event.set()
+
+    signal.signal(signal.SIGUSR1, _publish_drain)
 
 
 def _current_rss_bytes() -> int | None:
@@ -154,25 +193,23 @@ def run_worker(pipelines: list[str]):
     gpu_count = torch.cuda.device_count()
     if gpu_count > 1:
         logger.info(f"Found {gpu_count} GPUs, spawning one AMI worker instance per GPU")
+        # A process manager delivers signals to this parent process, which
+        # relays them to the group through this event. Both the event and its
+        # handler are set up before the first child exists, so a drain
+        # arriving at any point during startup is recorded rather than lost.
+        # The event has to come from the spawn context to be shareable with
+        # processes started by mp.spawn.
+        drain_event = mp.get_context("spawn").Event()
+        _install_parent_drain_handler(drain_event)
         # Don't pass settings through mp.spawn — Settings contains enums that
         # can't be pickled. Each child process calls read_settings() itself.
         context = mp.spawn(
             _worker_loop,
-            args=(pipelines,),
+            args=(pipelines, drain_event),
             nprocs=gpu_count,
             join=False,
         )
         assert context is not None
-        # Each worker instance installs its own SIGUSR1 drain handler, but a
-        # process supervisor delivers signals to this parent process —
-        # forward them so every instance drains and the whole group exits.
-        if hasattr(signal, "SIGUSR1"):
-
-            def _forward_drain(signum, frame):
-                for pid in context.pids():
-                    os.kill(pid, signal.SIGUSR1)
-
-            signal.signal(signal.SIGUSR1, _forward_drain)
         while not context.join():
             pass
     else:
@@ -183,20 +220,29 @@ def run_worker(pipelines: list[str]):
         _worker_loop(0, pipelines)
 
 
-def _worker_loop(gpu_id: int, pipelines: list[str]):
+def _worker_loop(
+    gpu_id: int, pipelines: list[str], drain_event: EventType | None = None
+):
     """Main polling loop for a single AMI worker instance, pinned to a specific GPU.
 
-    The loop runs until a drain is requested — by SIGUSR1 or by a
-    between-jobs recycle cap (see ``_after_job_check``) — and then returns
-    so the process exits with status 0 for its supervisor to restart.
+    The loop runs until a drain is requested — by SIGUSR1, by a between-jobs
+    recycle cap (see ``_after_job_check``), or by the parent of a multi-GPU
+    group — and then returns so the process exits with status 0 for its
+    process manager to restart.
 
     Args:
         gpu_id: GPU index to pin this AMI worker instance to (0 for CPU-only).
         pipelines: List of pipeline slugs to poll for jobs.
+        drain_event: Shared event the parent of a multi-GPU worker group sets
+            to ask this instance to drain. None when the worker runs
+            in-process and owns SIGUSR1 itself.
     """
-    settings = read_settings()
-    drain = _DrainRequest()
+    # Set up drain handling before any slower startup work, so a drain
+    # arriving early is recorded rather than acted on by SIGUSR1's default
+    # action of terminating the process.
+    drain = _DrainRequest(drain_event)
     _install_drain_handler(drain)
+    settings = read_settings()
     device = torch.device(f"cuda:{gpu_id}" if torch.cuda.is_available() else "cpu")
     if torch.cuda.is_available() and torch.cuda.device_count() > 0:
         torch.cuda.set_device(gpu_id)

--- a/trapdata/antenna/worker.py
+++ b/trapdata/antenna/worker.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import datetime
+import os
+import signal
 import time
 from collections.abc import Callable
 
@@ -28,6 +30,81 @@ from trapdata.settings import Settings, read_settings
 
 MAX_PENDING_POSTS = 5  # Maximum number of concurrent result posts before blocking
 SLEEP_TIME_SECONDS = 5
+
+_MIB = 1024 * 1024
+
+
+class _DrainRequest:
+    """A request for the worker process to exit at the next safe point.
+
+    Set by SIGUSR1 (an operator or process supervisor asking for a recycle)
+    or by the worker itself when its resident memory, sampled between jobs,
+    exceeds the ``worker_max_rss_mb`` cap. A safe point is a batch boundary:
+    the batch in flight finishes and its results are posted before the
+    process exits with status 0, so a process supervisor restarts a fresh
+    worker (fresh memory, file descriptors, and DataLoader state) without
+    losing in-flight work.
+    """
+
+    def __init__(self) -> None:
+        self.reason: str | None = None
+
+    @property
+    def requested(self) -> bool:
+        return self.reason is not None
+
+    def request(self, reason: str) -> None:
+        # The first reason wins; later triggers change nothing.
+        if self.reason is None:
+            self.reason = reason
+
+    def handle_signal(self, signum, frame) -> None:
+        logger.info(
+            "SIGUSR1 received: will finish the batch in flight, post its "
+            "results, and exit cleanly"
+        )
+        self.request("SIGUSR1")
+
+
+def _install_drain_handler(drain: _DrainRequest) -> None:
+    """Route SIGUSR1 to ``drain`` on platforms that have the signal."""
+    if hasattr(signal, "SIGUSR1"):
+        signal.signal(signal.SIGUSR1, drain.handle_signal)
+
+
+def _current_rss_bytes() -> int | None:
+    """Resident set size of this process, or None where /proc is unavailable."""
+    try:
+        with open("/proc/self/status") as status:
+            for line in status:
+                if line.startswith("VmRSS:"):
+                    return int(line.split()[1]) * 1024
+    except (OSError, ValueError):
+        return None
+    return None
+
+
+def _check_rss_cap(drain: _DrainRequest, max_rss_mb: int) -> None:
+    """Request a drain when resident memory exceeds the configured cap.
+
+    Called between jobs, when the working set is at its idle baseline, so a
+    reading over the cap indicates memory that survived per-job cleanup
+    rather than a job's transient working set. A cap of 0 (the default)
+    disables the check.
+    """
+    if max_rss_mb <= 0 or drain.requested:
+        return
+    rss_bytes = _current_rss_bytes()
+    if rss_bytes is None:
+        return
+    rss_mb = rss_bytes // _MIB
+    if rss_mb >= max_rss_mb:
+        logger.warning(
+            f"Resident memory {rss_mb} MiB is over the {max_rss_mb} MiB cap "
+            "(AMI_WORKER_MAX_RSS_MB); exiting cleanly so the process "
+            "supervisor restarts a fresh worker"
+        )
+        drain.request(f"resident memory {rss_mb} MiB over the {max_rss_mb} MiB cap")
 
 
 def run_worker(pipelines: list[str]):
@@ -57,12 +134,25 @@ def run_worker(pipelines: list[str]):
         logger.info(f"Found {gpu_count} GPUs, spawning one AMI worker instance per GPU")
         # Don't pass settings through mp.spawn — Settings contains enums that
         # can't be pickled. Each child process calls read_settings() itself.
-        mp.spawn(
+        context = mp.spawn(
             _worker_loop,
             args=(pipelines,),
             nprocs=gpu_count,
-            join=True,
+            join=False,
         )
+        assert context is not None
+        # Each worker instance installs its own SIGUSR1 drain handler, but a
+        # process supervisor delivers signals to this parent process —
+        # forward them so every instance drains and the whole group exits.
+        if hasattr(signal, "SIGUSR1"):
+
+            def _forward_drain(signum, frame):
+                for pid in context.pids():
+                    os.kill(pid, signal.SIGUSR1)
+
+            signal.signal(signal.SIGUSR1, _forward_drain)
+        while not context.join():
+            pass
     else:
         if gpu_count == 1:
             logger.info(f"Found 1 GPU: {torch.cuda.get_device_name(0)}")
@@ -74,11 +164,17 @@ def run_worker(pipelines: list[str]):
 def _worker_loop(gpu_id: int, pipelines: list[str]):
     """Main polling loop for a single AMI worker instance, pinned to a specific GPU.
 
+    The loop runs until a drain is requested — by SIGUSR1 or by the
+    between-jobs resident-memory cap — and then returns so the process exits
+    with status 0 for its supervisor to restart.
+
     Args:
         gpu_id: GPU index to pin this AMI worker instance to (0 for CPU-only).
         pipelines: List of pipeline slugs to poll for jobs.
     """
     settings = read_settings()
+    drain = _DrainRequest()
+    _install_drain_handler(drain)
     device = torch.device(f"cuda:{gpu_id}" if torch.cuda.is_available() else "cpu")
     if torch.cuda.is_available() and torch.cuda.device_count() > 0:
         torch.cuda.set_device(gpu_id)
@@ -90,7 +186,7 @@ def _worker_loop(gpu_id: int, pipelines: list[str]):
     full_service_name = get_full_service_name(settings.antenna_service_name)
     logger.info(f"Running worker as: {full_service_name}")
 
-    while True:
+    while not drain.requested:
         # TODO CGJS: Support pulling and prioritizing single image tasks, which are used in interactive testing
         # These should probably come from a dedicated endpoint and should preempt batch jobs under the assumption that they
         # would run on the same GPU.
@@ -104,6 +200,8 @@ def _worker_loop(gpu_id: int, pipelines: list[str]):
             pipeline_slugs=pipelines,
         )
         for job_id, pipeline in jobs:
+            if drain.requested:
+                break
             logger.info(
                 f"[GPU {gpu_id}] Processing job {job_id} with pipeline {pipeline}"
             )
@@ -113,6 +211,7 @@ def _worker_loop(gpu_id: int, pipelines: list[str]):
                     job_id=job_id,
                     settings=settings,
                     device=device,
+                    should_stop=lambda: drain.requested,
                 )
                 any_jobs = any_jobs or any_work_done
             except Exception as e:
@@ -121,12 +220,20 @@ def _worker_loop(gpu_id: int, pipelines: list[str]):
                     exc_info=True,
                 )
                 # Continue to next job rather than crashing the worker
+            # Between jobs the working set is at its baseline, so this is
+            # where leaked memory is distinguishable from a busy working set.
+            _check_rss_cap(drain, settings.worker_max_rss_mb)
 
-        if not any_jobs:
+        if not any_jobs and not drain.requested:
             logger.info(
                 f"[GPU {gpu_id}] No jobs found, sleeping for {SLEEP_TIME_SECONDS} seconds"
             )
             time.sleep(SLEEP_TIME_SECONDS)
+
+    logger.info(
+        f"[GPU {gpu_id}] Drain complete ({drain.reason}); exiting cleanly for "
+        "the process supervisor to restart a fresh worker"
+    )
 
 
 def _apply_binary_classification(
@@ -403,6 +510,7 @@ def _process_job(
     settings: Settings,
     device: torch.device | None = None,
     on_batch_complete: Callable | None = None,
+    should_stop: Callable[[], bool] | None = None,
 ) -> bool:
     """Run the worker to process images from the REST API queue.
 
@@ -413,6 +521,10 @@ def _process_job(
         device: The device to use for processing. Auto-detected if None.
         on_batch_complete: Optional callback invoked after each batch, with kwargs
             batch_num (int) and items (int, cumulative items processed so far).
+        should_stop: Optional callable checked at every batch boundary. When
+            it returns True the job stops before starting another batch:
+            results for completed batches are still posted, and the job's
+            remaining tasks stay queued for the next worker to claim.
     Returns:
         True if any work was done, False otherwise
     """
@@ -453,6 +565,13 @@ def _process_job(
     _, t_total = log_time()
     try:
         for i, batch in enumerate(batch_source):
+            if should_stop and should_stop():
+                logger.info(
+                    f"Stop requested; leaving job {job_id} at a batch "
+                    "boundary. Remaining tasks stay queued for the next "
+                    "worker to claim."
+                )
+                break
             cls_time = 0.0
             det_time = 0.0
             load_time, t = t()
@@ -506,7 +625,7 @@ def _process_job(
             )
             batch_total, t_total = t_total()
             logger.info(
-                f"Batch {i + 1}: {batch_total/max(n_items, 1):.2f}s/image, "
+                f"Batch {i + 1}: {batch_total / max(n_items, 1):.2f}s/image, "
                 f"Classification time: {cls_time:.2f}s, Detection time: {det_time:.2f}s, "
                 f"Load time: {load_time:.2f}s"
             )

--- a/trapdata/settings.py
+++ b/trapdata/settings.py
@@ -46,6 +46,9 @@ class Settings(BaseSettings):
     # resident memory, sampled between jobs, exceeds this many MiB.
     # 0 disables the cap.
     worker_max_rss_mb: int = 0
+    # The worker exits cleanly after processing this many jobs. Bounds
+    # memory retained per job even when its size is not known. 0 disables.
+    worker_max_jobs: int = 0
 
     @pydantic.field_validator("image_base_path", "user_data_path")
     def validate_path(cls, v):

--- a/trapdata/settings.py
+++ b/trapdata/settings.py
@@ -42,6 +42,10 @@ class Settings(BaseSettings):
     antenna_api_auth_token: str = ""
     antenna_service_name: str = "AMI Data Companion"
     antenna_api_batch_size: int = 24
+    # The worker exits cleanly (for its process supervisor to restart) when
+    # resident memory, sampled between jobs, exceeds this many MiB.
+    # 0 disables the cap.
+    worker_max_rss_mb: int = 0
 
     @pydantic.field_validator("image_base_path", "user_data_path")
     def validate_path(cls, v):

--- a/trapdata/settings.py
+++ b/trapdata/settings.py
@@ -43,7 +43,7 @@ class Settings(BaseSettings):
     antenna_service_name: str = "AMI Data Companion"
     antenna_api_batch_size: int = 24
     # The worker exits cleanly (for its process manager to restart) when
-    # resident memory, sampled between jobs, exceeds this many MiB.
+    # resident memory, sampled between jobs, reaches or exceeds this many MiB.
     # Only 0 disables the cap, so a negative value is rejected rather than
     # silently turning the cap off.
     worker_max_rss_mb: int = Field(default=0, ge=0)

--- a/trapdata/settings.py
+++ b/trapdata/settings.py
@@ -42,13 +42,14 @@ class Settings(BaseSettings):
     antenna_api_auth_token: str = ""
     antenna_service_name: str = "AMI Data Companion"
     antenna_api_batch_size: int = 24
-    # The worker exits cleanly (for its process supervisor to restart) when
+    # The worker exits cleanly (for its process manager to restart) when
     # resident memory, sampled between jobs, exceeds this many MiB.
-    # 0 disables the cap.
-    worker_max_rss_mb: int = 0
+    # Only 0 disables the cap, so a negative value is rejected rather than
+    # silently turning the cap off.
+    worker_max_rss_mb: int = Field(default=0, ge=0)
     # The worker exits cleanly after processing this many jobs. Bounds
     # memory retained per job even when its size is not known. 0 disables.
-    worker_max_jobs: int = 0
+    worker_max_jobs: int = Field(default=0, ge=0)
 
     @pydantic.field_validator("image_base_path", "user_data_path")
     def validate_path(cls, v):


### PR DESCRIPTION
## Summary

The ML worker's host memory grows with the work it has done and is not released while the process lives. Two rounds of measurement on two production GPU hosts (2026-08-11):

- After several days of jobs, idle worker processes held 6.0, 9.5, and 17.1 GB of resident memory, while a control worker from the same image on the same hosts that had processed very little sat at a 0.9 GB baseline.
- After a clean restart of every worker, a process that had completed **exactly one job** held 13.1–15.1 GB while idle, within 90 minutes of starting — and the worker whose job was roughly 400 images retained about as much as the one whose job was roughly 3,200 images. That reads as **per-job retention of roughly fixed size** (models, pipeline objects, DataLoader machinery allocated per job and never freed), rather than the time-based "GB per hour" ramp we previously assumed, and not proportional to image count either.

Caveat, stated plainly: the second round is two samples, and both processes had loaded models for the first time in that window — a long-lived worker is *supposed* to hold resident model weights, so some of that 13–15 GB may be legitimate. The distinguishing test is whether RSS climbs further after a second and third job, which has not been run yet. This PR builds the instrument for it (see change 3 below). These hosts run without swap, so if per-job retention is real, the terminal state on a 68 GB host is a hard kernel OOM after roughly four to five jobs per process — an outage, not a slowdown.

This is a separate defect from the GPU out-of-memory failures addressed in PR #162. That one is a fixed peak working set colliding with a co-tenant process on a shared card (the same 426 MiB allocation failing 504 times at a stable 13.49 GiB allocated — no drift). This one is unbounded growth of ordinary host memory that scales with jobs processed; idle GPU memory retention measured at the same moment was only 124–722 MiB per process, and the DataLoader subprocesses suspected of the retention (#144 Part B, #145) never touch CUDA. Different memory, different processes, different mechanism, different fix; conflating them cost days of triage earlier.

This PR does not fix the leak — it bounds the damage, implementing the drain-and-exit proposal from #147. A worker can be told (or can decide on its own, via opt-in caps) to finish the batch in flight, post its results, and exit cleanly with status 0, so its process supervisor restarts a fresh process. Any leak — this one or a future one — becomes routine process churn instead of a host outage.

Why this change rather than the alternatives on the table: #144 Part A (LRU model eviction) manages GPU memory of idle models, not this host-RAM growth, and is gated on the leak audit; the root-cause work in #145 first needs instrumentation to find the retaining call sites; PR #148 improves DataLoader hygiene and by its own measurements removes the catastrophic per-job blow-up, but residual growth across jobs remains (its RSS figures do not return to baseline). And if retention really is per-job, recycling after N jobs caps it deterministically without the leak ever being located. Bounded process lifetime is the smallest change that does that, and it stays useful as defense in depth after the underlying bugs are fixed. It complements #148 rather than overlapping it — #148 explicitly lists worker recycling as out of scope.

### List of Changes

1. **Operators can recycle a worker without losing in-flight work.** Sending SIGUSR1 (for example `supervisorctl signal USR1 <program>`) makes the worker finish the batch it is processing, post those results, and exit with status 0 for the supervisor to restart. The only lever before this was SIGTERM, which kills mid-batch and forces queue redelivery of the in-flight work.
2. **A worker can bound its own memory retention, by job count or by size.** Two new settings, both default-off: `AMI_WORKER_MAX_JOBS` drains the worker after that many jobs — the deterministic bound, since job count is what the measurements say predicts growth; `AMI_WORKER_MAX_RSS_MB` drains when resident memory sampled between jobs exceeds the cap — the backstop for whatever the job count does not predict. A job that raised mid-processing counts toward the job cap (it may retain memory like a completed one); job claims that yielded no work do not.
3. **Every job leaves a memory data point in the logs.** The worker logs `Resident memory after job N: X MiB` between jobs, when the working set is at its idle baseline. This makes the open question above — does RSS keep climbing after jobs 2 and 3, or plateau after the first model load? — answerable from ordinary production logs, with no host instrumentation.
4. **Long jobs stop at batch boundaries, never mid-batch.** `_process_job` accepts a `should_stop` callable checked at every batch boundary. On a stop, results for completed batches are still flushed, and the job's remaining tasks stay queued for the next worker (or the restarted one) to claim.
5. **Multi-GPU hosts drain as a group.** Process supervisors deliver signals to the parent process only, so the parent forwards SIGUSR1 to each spawned per-GPU worker instance.
6. **Tests** (`trapdata/antenna/tests/test_worker_drain.py`, 16 tests): the signal handler and drain state; both recycle caps in both directions (fire past their threshold, stay silent at the 0 default — a cap that fired while disabled would recycle every deployment that did not opt in); the per-job log line; the batch-boundary stop with and without a stop request; and the polling loop exiting after a signal.

## What draining does and does not guarantee

- Guaranteed: the batch in flight completes, its results are posted, and the process exits 0. No mid-batch kill, no half-posted batch.
- Not guaranteed: batches the DataLoader has already prefetched but not yet processed are not processed; their tasks return through the queue's normal redelivery timeout, exactly as with any worker restart today.
- The recycle caps are checked between jobs only, so a single very long job can still grow past the memory cap while it runs. If observation shows that matters in practice, a between-batches check is a small follow-up.

## What still needs verification

- **The distinguishing test for the per-job retention hypothesis**: run three or more jobs back-to-back on one worker and read the new per-job memory log line. Climbing values job over job indicate real per-job leakage; a plateau after job 1 indicates first-load model residency and shifts the fix toward #144/#145. This PR provides the instrument but the test has not been run.
- The drain path is exercised by unit tests with mocked inference only — it has not yet run against a live deployment. To verify on a dev host: start a multi-batch job, send SIGUSR1 mid-job, and confirm the current batch completes, the process exits 0, the supervisor restarts it, and the job continues on the fresh process.
- Sensible cap values for the production hosts. If per-job retention of ~13–15 GB is real, `AMI_WORKER_MAX_JOBS` in the low single digits is the operative bound on a 68 GB host running multiple workers; the RSS cap needs an observation cycle before recommending a number. Both need the distinguishing test first.
- Whether the growth lives mostly in the DataLoader subprocesses or the main worker process. The recycle bounds both, but the answer directs the root-cause fix in #145.

## Relationship to other open work

- Implements #147 (closes #147). The operator-side triggers (cron schedules, health-driven scripts) stay out of this repo, as that issue specifies.
- Complements PR #148 (DataLoader forkserver/timeout/teardown): #148 reduces what leaks; this bounds what remains and covers what it misses.
- Leaves #144 (leak audit + LRU eviction), #145 (pipe FD leak root cause), and #140 (DataLoader deadlock) open — this PR is the floor under all of them, not a substitute. The FD leak in #145 also benefits: a recycled worker resets its descriptor count, and the cap can be extended to descriptors later if needed.

## Test and lint results

- New drain tests: 16/16 pass.
- Full suite (`uv run pytest --import-mode=importlib`): 54 passed, 1 skipped, 1 failed — the failure is `trapdata/api/tests/test_models.py::TestSourceImageSchema::test_url`, which live-fetches an image from Wikimedia and received an HTTP 400 from the external server; pre-existing environmental flake, unrelated to this branch.
- pre-commit (black, isort, flake8 + bugbear, autoflake): all hooks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HcXFHJRXMrsHPX7xz9ZifF


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added graceful worker recycling through signal requests, job-count limits, and resident-memory limits.
  * Workers now finish in-progress work, flush results, and stop cleanly at batch boundaries.
  * Added configurable settings for job and memory limits; setting either to `0` disables that limit.
* **Documentation**
  * Documented worker recycling configuration and supervisor restart requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->