### PR TITLE
Stop three tests failing on every pull request

### DIFF
--- a/trapdata/api/tests/test_api.py
+++ b/trapdata/api/tests/test_api.py
@@ -15,7 +15,11 @@ from trapdata.api.api import (
 )
 from trapdata.api.schemas import PipelineConfigRequest
 from trapdata.api.tests.image_server import StaticFileTestServer
-from trapdata.api.tests.utils import get_test_images, get_pipeline_class
+from trapdata.api.tests.utils import (
+    IMAGE_WITH_DETECTIONS,
+    get_pipeline_class,
+    get_test_images,
+)
 from trapdata.tests import TEST_IMAGES_BASE_PATH
 
 logging.basicConfig(level=logging.INFO)
@@ -38,8 +42,15 @@ class TestInferenceAPI(TestCase):
         if hasattr(cls, "file_server"):
             cls.file_server.stop()
 
-    def get_test_images(self, subdir: str = "vermont", num: int = 2):
-        return get_test_images(self.file_server, self.test_images_dir, subdir, num)
+    def get_test_images(
+        self,
+        subdir: str = "vermont",
+        num: int = 2,
+        filenames: list[str] | None = None,
+    ):
+        return get_test_images(
+            self.file_server, self.test_images_dir, subdir, num, filenames
+        )
 
     def get_test_pipeline(self, slug: str = "quebec_vermont_moths_2023"):
         return get_pipeline_class(slug)
@@ -127,7 +138,7 @@ class TestInferenceAPI(TestCase):
         Test that the logits are included in the classification response when
         requested via the pipeline configuration.
         """
-        test_images = self.get_test_images(num=1)
+        test_images = self.get_test_images(filenames=[IMAGE_WITH_DETECTIONS])
         assert test_images, "No test images found"
 
         test_pipeline_slug = "insect_orders_2025"
@@ -176,7 +187,7 @@ class TestInferenceAPI(TestCase):
         Test that classification responses have no labels (from algorithm config)
         and scores/logits count equals num classes in category map.
         """
-        test_images = self.get_test_images(num=1)
+        test_images = self.get_test_images(filenames=[IMAGE_WITH_DETECTIONS])
         assert test_images, "No test images found"
 
         test_pipeline_slug = "insect_orders_2025"

--- a/trapdata/api/tests/test_models.py
+++ b/trapdata/api/tests/test_models.py
@@ -21,6 +21,7 @@ from trapdata.api.schemas import (
     DetectionResponse,
     SourceImage,
 )
+from trapdata.api.tests.image_server import StaticFileTestServer
 from trapdata.common.filemanagement import find_images
 from trapdata.tests import TEST_IMAGES_BASE_PATH
 
@@ -260,19 +261,30 @@ class TestSourceImageSchema(TestCase):
         img.close()
 
     def test_url(self):
-        # Don't trust placeholder image services
-        # Don't trust placeholder image services
-        url = (
-            "https://upload.wikimedia.org/wikipedia/en/thumb/8/80/"
-            "Wikipedia-logo-v2.svg/103px-Wikipedia-logo-v2.svg.png"
-        )
-        source_image = SourceImage(id="1", url=url)
-        self.assertEqual(source_image.url, url)
-        img = source_image.open()
-        self.assertIsNotNone(img)
-        assert img is not None
-        self.assertEqual(img.size, (103, 94))
-        img.close()
+        """
+        A source image created from a URL downloads the image and reads its size.
+
+        The image is served by a local HTTP server rather than fetched from the
+        public internet, so the test does not break when a third-party host
+        becomes unreachable or changes which image sizes it will serve. The
+        dimensions are deliberately unequal so the assertion would catch a
+        mixed-up or placeholder image rather than only a failed download.
+        """
+        image_size = (103, 94)
+        with tempfile.TemporaryDirectory() as served_dir:
+            filename = "source-image.png"
+            PIL.Image.new("RGB", image_size, color="blue").save(  # type: ignore
+                pathlib.Path(served_dir) / filename
+            )
+            with StaticFileTestServer(served_dir) as file_server:
+                url = file_server.get_url(filename)
+                source_image = SourceImage(id="1", url=url)
+                self.assertEqual(source_image.url, url)
+                img = source_image.open()
+                self.assertIsNotNone(img)
+                assert img is not None
+                self.assertEqual(img.size, image_size)
+                img.close()
 
     def test_bad_base64(self):
         base64_string = "happy birthday"

--- a/trapdata/api/tests/utils.py
+++ b/trapdata/api/tests/utils.py
@@ -11,12 +11,20 @@ from trapdata.api.api import CLASSIFIER_CHOICES, APIMothClassifier
 from trapdata.api.schemas import SourceImageRequest
 from trapdata.api.tests.image_server import StaticFileTestServer
 
+# A Vermont trap image that the moth detector finds objects in. Tests asserting
+# on detections or classifications must name the image they use: the Vermont
+# sample also contains a frame where nothing clears the detector's score
+# threshold, so a test that takes whichever image comes first has no guarantee
+# there is anything to assert on.
+IMAGE_WITH_DETECTIONS = "20220622000459-108-snapshot.jpg"
+
 
 def get_test_image_urls(
     file_server: StaticFileTestServer,
     test_images_dir: Path,
     subdir: str = "vermont",
     num: int = 2,
+    filenames: list[str] | None = None,
 ) -> list[str]:
     """Get list of test image URLs from file server.
 
@@ -25,16 +33,20 @@ def get_test_image_urls(
         test_images_dir: Base directory containing test images
         subdir: Subdirectory within test_images_dir (default: "vermont")
         num: Number of images to return (default: 2)
+        filenames: Specific image filenames within subdir. When omitted, the
+            first `num` images are taken in sorted order, which keeps the
+            selection the same on every machine. Directory order is arbitrary
+            and differs between checkouts.
 
     Returns:
         List of image URLs from the file server
     """
     images_dir = test_images_dir / subdir
-    source_image_urls = [
-        file_server.get_url(f.relative_to(test_images_dir))
-        for f in images_dir.glob("*.jpg")
-    ][:num]
-    return source_image_urls
+    if filenames is None:
+        paths = sorted(images_dir.glob("*.jpg"))[:num]
+    else:
+        paths = [images_dir / filename for filename in filenames]
+    return [file_server.get_url(path.relative_to(test_images_dir)) for path in paths]
 
 
 def get_test_images(
@@ -42,6 +54,7 @@ def get_test_images(
     test_images_dir: Path,
     subdir: str = "vermont",
     num: int = 2,
+    filenames: list[str] | None = None,
 ) -> list[SourceImageRequest]:
     """Get list of SourceImageRequest objects for testing.
 
@@ -50,11 +63,13 @@ def get_test_images(
         test_images_dir: Base directory containing test images
         subdir: Subdirectory within test_images_dir (default: "vermont")
         num: Number of images to return (default: 2)
+        filenames: Specific image filenames within subdir, as described on
+            get_test_image_urls.
 
     Returns:
         List of SourceImageRequest objects with IDs and URLs
     """
-    urls = get_test_image_urls(file_server, test_images_dir, subdir, num)
+    urls = get_test_image_urls(file_server, test_images_dir, subdir, num, filenames)
     source_images = [
         SourceImageRequest(id=str(i), url=url) for i, url in enumerate(urls)
     ]


### PR DESCRIPTION
## Summary

Three tests fail on pull requests for reasons unrelated to what those pull requests change. One fails on every run: it downloads a thumbnail from Wikimedia, which now refuses arbitrary thumbnail widths and returns an HTTP 400 pointing at its allowed-sizes policy. The other two fail intermittently: they test whichever sample image the filesystem happens to list first, and one of the sample images is an empty frame with nothing for the detector to find. This makes all three reliable, by serving the thumbnail from a local test server and by having tests pick their images deterministically. No application code changes; the fixes are entirely in the tests and their helpers.

None of this was caused by an open pull request. The last test run on `main` (2026-04-14) passed. The Wikimedia change happened after that, and `main` has not had a test run since, so its green status is out of date rather than evidence that the suite still passes.

The two intermittent failures were not network problems at all. The two API tests asked for "the first" trap image and then checked that the ML pipeline found insects in it. The helper picked that image from an unsorted directory listing, so which image a test got depended on filesystem ordering, which differs between checkouts and between runs. When the listing put the empty Vermont frame first, the pipeline correctly returned no detections and the test had nothing to assert on. Whenever it put a different image first, the same tests passed, which is why they looked flaky rather than broken.

### List of Changes

| # | Change (what it means for the reader) | How (implementation) |
|---|---|---|
| 1 | Tests that check the ML pipeline found insects always run against an image that actually contains insects, instead of whichever image the filesystem happened to return first. | `test_logits_in_classification_response` and `test_config_num_classification_predictions` pass an explicit filename via a new `IMAGE_WITH_DETECTIONS` constant in `trapdata/api/tests/utils.py`. |
| 2 | Every test that pulls sample images gets the same images on every machine and every run. This includes the Antenna worker and memory-leak tests, which now also receive images in sorted order; they already allow for an image without detections, so what they check is unchanged. | `get_test_image_urls` sorts the glob result and accepts an optional `filenames` argument, added last so existing callers are unaffected. The helpers pass `subdir`, `num` and `filenames` to each other by keyword. |
| 3 | The source image URL test no longer reaches out to the public internet, so it cannot break again when a third-party host changes what it will serve. | `test_url` writes an image to a temporary directory and serves it through `StaticFileTestServer`, which the repository already uses for this purpose. The same download-and-open code path is exercised, and the image has unequal dimensions so a mixed-up image would be caught, not only a failed download. |

### Verification

When this pull request was opened (2026-08-12), run against this branch with the GPU disabled, matching the CPU-only CI runners:

- Full suite: 39 passed, 1 skipped, 0 failed.
- The three previously failing tests passed.
- Negative control: temporarily pointing `IMAGE_WITH_DETECTIONS` at the empty frame reproduced the exact CI failure (`AssertionError: No detections found in response`), confirming the image choice is what these tests turn on.
- Pinned tooling was clean on the changed files: black 22.3.0, isort 5.11.5, flake8 4.0.0 with bugbear and comprehensions, autoflake 1.4.

Rechecked on 2026-09-11, during review:

- The three tests pass on this branch, and with this branch merged into #168. The pipeline tests used locally cached model weights, so this confirms the test changes, not the downloads.
- #168's CI, which does not include this branch, fails only `TestSourceImageSchema::test_url`, with 54 other tests passing on Python 3.10 and 3.12.

### Notes for reviewers

- **Merge this together with #168, this one first.** The model weights these tests download were hosted on an object store that was retired in the recent storage move, and that host now returns HTTP 403. CI has no model cache, so any fresh CI run of this branch on its own is expected to fail on those downloads. The green checks from 2026-08-12 predate the move, and the run triggered by the latest commit here is likely to go red for this reason. #168 points model downloads at the new store, and its only failing test is the one this pull request fixes. Merging this first and then updating #168's branch should give a fully green run.
- The detector threshold and the empty Vermont frame are both left as they are. An image with no insects in it is a reasonable thing to keep in the sample set, and the detector returning nothing for it is correct behaviour; the bug was that a test could land on it by accident.
- The ML tests still download model weights from a remote object store at test time. That dependency is what broke after the storage move; caching the weights in CI would remove it and is worth a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
