### PR TITLE
[Draft] Make processing service support model retraining

### DIFF
--- a/trapdata/api/api.py
+++ b/trapdata/api/api.py
@@ -111,6 +111,7 @@ def make_algorithm_response(
         description=model.description,
         category_map=category_map,
         uri=model.weights_path,
+        trainable=getattr(model, "trainable", False),
     )
 
 
@@ -125,6 +126,7 @@ def make_algorithm_config_response(
         description=model.description,
         category_map=category_map,
         uri=model.weights_path,
+        trainable=getattr(model, "trainable", False),
     )
 
 

--- a/trapdata/api/schemas.py
+++ b/trapdata/api/schemas.py
@@ -226,6 +226,14 @@ class AlgorithmConfigResponse(pydantic.BaseModel):
         default=None,
         description="A URI to the weights or model details, could be a public web URL or object store path.",
     )
+    trainable: bool = pydantic.Field(
+        default=False,
+        description=(
+            "Whether this algorithm can be retrained from labelled data. Antenna reads this "
+            "to decide whether retraining can be offered for the algorithm. Only a classifier "
+            "head over a frozen backbone is cheap enough to retrain; a detector is not."
+        ),
+    )
     category_map: AlgorithmCategoryMapResponse | None = None
 
 

--- a/trapdata/ml/models/base.py
+++ b/trapdata/ml/models/base.py
@@ -77,6 +77,10 @@ class InferenceBaseClass:
     labels_path = None
     category_map = {}
     num_classes: Union[int, None] = None  # Will use len(category_map) if None
+    # Whether this model's classifier head can be retrained from labelled data without
+    # touching the backbone. Reported to Antenna so it can offer retraining only where it
+    # is cheap. Off by default: a detector, and any model trained end to end, is not.
+    trainable: bool = False
     lookup_gbif_names: bool = False
     default_taxon_rank: str = "SPECIES"
     model: torch.nn.Module

--- a/trapdata/tests/test_trainable_flag.py
+++ b/trapdata/tests/test_trainable_flag.py
@@ -1,0 +1,45 @@
+"""
+A processing service tells Antenna which of its algorithms can be retrained.
+
+Only a classifier head over a frozen backbone is cheap enough to retrain, so the flag is
+per algorithm rather than per service.
+"""
+
+from trapdata.api.api import make_algorithm_config_response, make_algorithm_response
+from trapdata.api.schemas import AlgorithmConfigResponse
+from trapdata.ml.models.base import InferenceBaseClass
+
+
+class _FakeModel:
+    name = "Fake classifier"
+    task_type = "classification"
+    description = "For testing the trainable flag."
+    weights_path = None
+    category_map = {}
+
+    def get_key(self):
+        return "fake-classifier"
+
+
+def test_models_are_not_trainable_by_default():
+    assert InferenceBaseClass.trainable is False
+
+
+def test_the_response_defaults_to_not_trainable():
+    assert AlgorithmConfigResponse(name="x", key="x").trainable is False
+
+
+def test_a_model_that_declares_trainable_is_reported_as_such(monkeypatch):
+    """Antenna reads this to decide whether retraining can be offered."""
+    model = _FakeModel()
+    monkeypatch.setattr(model, "trainable", True, raising=False)
+    monkeypatch.setattr("trapdata.api.api.make_category_map_response", lambda m: None)
+
+    assert make_algorithm_response(model).trainable is True
+    assert make_algorithm_config_response(model).trainable is True
+
+
+def test_a_model_without_the_attribute_is_not_trainable():
+    """Older models predate the flag and must not be treated as trainable."""
+    monkey = _FakeModel()
+    assert getattr(monkey, "trainable", False) is False


### PR DESCRIPTION
## Summary

Antenna is gaining the ability to retrain a classifier head from species that people have verified. Only some models are worth retraining — a classifier head over a frozen backbone is cheap, a detector or a model trained end to end is not — so Antenna needs to be told which is which before it can offer retraining for a pipeline.

This adds that one flag. A model declares `trainable`, the worker reports it in the algorithm config it registers with Antenna, and Antenna uses it to decide whether retraining applies. Nothing else changes: no model is trainable unless it says so, and nothing here trains anything.

### List of Changes

| # | What it does | How |
|---|---|---|
| 1 | A model can declare that its head can be retrained | `trainable` attribute on `InferenceBaseClass`, defaulting to `False` |
| 2 | Antenna is told which algorithms can be retrained | `trainable` field on `AlgorithmConfigResponse` |
| 3 | Both places that build an algorithm response pass the flag through | `make_algorithm_response()` and `make_algorithm_config_response()` |

## Detailed Description

The flag is per algorithm rather than per service. A processing service usually hosts several pipelines and only one of them has a retrainable head, so a single service-level flag would not tell Antenna which head to touch.

The default is `False` everywhere, and the builders read it with `getattr(model, "trainable", False)`, so a model written before this change is treated as not trainable rather than being assumed retrainable.

This matches the field Antenna reads from `/info`, which it mirrors onto its own `Algorithm` records. The corresponding Antenna change is in RolnickLab/antenna#1407.

## Verification

`trapdata/tests/test_trainable_flag.py` covers the default, the response default, a model that declares the flag, and a model that predates the attribute.

**Note:** these tests have not been run locally — the working tree had no Python environment and building one pulls in torch. The schema field itself was checked in isolation with pydantic. CI runs the rest.
